### PR TITLE
Fix formatting and run clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Bluetooth Low Energy Fundamentals Course Exercises
 This repository is part of the [Bluetooth Low Energy Fundamentals](https://academy.nordicsemi.com/courses/bluetooth-low-energy-fundamentals/) course by [Nordic Developer Academy](https://academy.nordicsemi.com).
 
-The Bluetooth Low Energy Fundamentals course is an online, self-paced course that focuses on teaching the basics of Bluetooth LE using Nordic Semiconductor devices (nRF52 and nRF53 Series). 
+The Bluetooth Low Energy Fundamentals course is an online, self-paced course that focuses on teaching the basics of Bluetooth LE using Nordic Semiconductor devices (nRF52 and nRF53 Series).
 
 Through hands-on learning, participants will learn how to create a Bluetooth LE prototype and establish a wireless, unidirectional and bidirectional data channel between two Bluetooth-LE-enabled devices in a short period of time.
-Upon completion of the course, participants will have a thorough understanding of the Bluetooth LE protocol and its layers, as well as knowledge of available APIs in the nRF Connect SDK, which is based on the Zephyr RTOS. 
+Upon completion of the course, participants will have a thorough understanding of the Bluetooth LE protocol and its layers, as well as knowledge of available APIs in the nRF Connect SDK, which is based on the Zephyr RTOS.
 
 Additionally, participants will have gained practical experience in configuring Bluetooth LE advertisements and connections, as well as insight into securing Bluetooth LE connections and inspecting packets over the air using nRF Sniffer.

--- a/lesson1/blefund_less1_exer1/prj.conf
+++ b/lesson1/blefund_less1_exer1/prj.conf
@@ -14,6 +14,6 @@ CONFIG_BT_LBS=y
 CONFIG_BT_LBS_POLL_BUTTON=y
 CONFIG_DK_LIBRARY=y
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson1/blefund_less1_exer1/src/main.c
+++ b/lesson1/blefund_less1_exer1/src/main.c
@@ -26,17 +26,16 @@
 
 #include <dk_buttons_and_leds.h>
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
+#define USER_LED DK_LED3
 
-#define USER_LED                DK_LED3
-
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
 static bool app_button_state;
 
@@ -69,8 +68,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 #ifdef CONFIG_BT_LBS_SECURITY_ENABLED
-static void security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -79,15 +77,14 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		printk("Security changed: %s level %u\n", addr, level);
 	} else {
-		printk("Security failed: %s level %u err %d\n", addr, level,
-			err);
+		printk("Security failed: %s level %u err %d\n", addr, level, err);
 	}
 }
 #endif
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected        = connected,
-	.disconnected     = disconnected,
+	.connected = connected,
+	.disconnected = disconnected,
 #ifdef CONFIG_BT_LBS_SECURITY_ENABLED
 	.security_changed = security_changed,
 #endif
@@ -135,10 +132,9 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 };
 
-static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
-	.pairing_complete = pairing_complete,
-	.pairing_failed = pairing_failed
-};
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = { .pairing_complete =
+									pairing_complete,
+								.pairing_failed = pairing_failed };
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
 static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
@@ -155,7 +151,7 @@ static bool app_button_cb(void)
 }
 
 static struct bt_lbs_cb lbs_callbacs = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -232,8 +228,7 @@ void main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson2/blefund_less2_exer1/prj.conf
+++ b/lesson2/blefund_less2_exer1/prj.conf
@@ -7,15 +7,15 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
 # STEP 1 - Include the Bluetooth LE stack in your project
 
-# STEP 2 - Set the Bluetooth LE device name 
+# STEP 2 - Set the Bluetooth LE device name
 
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson2/blefund_less2_exer1/src/main.c
+++ b/lesson2/blefund_less2_exer1/src/main.c
@@ -44,7 +44,7 @@ void main(void)
     /* STEP 5 - Enable the Bluetooth LE stack */
 
 
-	
+
 	/* STEP 6 - Start advertising */
 
 

--- a/lesson2/blefund_less2_exer1/src/main.c
+++ b/lesson2/blefund_less2_exer1/src/main.c
@@ -4,30 +4,25 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 /* STEP 3 - Include the header file of the Bluetooth LE stack */
-
 
 #include <dk_buttons_and_leds.h>
 
 LOG_MODULE_REGISTER(Lesson2_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define RUN_LED_BLINK_INTERVAL 1000
 
 /* STEP 4.1.1 - Declare the advertising packet */
 
-
 /* STEP 4.2.2 - Declare the URL data to include in the scan response */
 
-
 /* STEP 4.2.1 - Declare the scan response packet */
-
 
 void main(void)
 {
@@ -43,10 +38,7 @@ void main(void)
 	}
 	/* STEP 5 - Enable the Bluetooth LE stack */
 
-
-
 	/* STEP 6 - Start advertising */
-
 
 	LOG_INF("Advertising successfully started\n");
 

--- a/lesson2/blefund_less2_exer1/src/main.c
+++ b/lesson2/blefund_less2_exer1/src/main.c
@@ -41,7 +41,7 @@ void main(void)
 		LOG_ERR("LEDs init failed (err %d)\n", err);
 		return;
 	}
-    /* STEP 5 - Enable the Bluetooth LE stack */
+	/* STEP 5 - Enable the Bluetooth LE stack */
 
 
 

--- a/lesson2/blefund_less2_exer1_solution/prj.conf
+++ b/lesson2/blefund_less2_exer1_solution/prj.conf
@@ -7,15 +7,15 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
 # STEP 1 - Include the Bluetooth LE stack in your project
 CONFIG_BT=y
-# STEP 2 - Set the Bluetooth LE device name 
+# STEP 2 - Set the Bluetooth LE device name
 CONFIG_BT_DEVICE_NAME="Nordic_Beacon"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson2/blefund_less2_exer1_solution/src/main.c
+++ b/lesson2/blefund_less2_exer1_solution/src/main.c
@@ -61,7 +61,7 @@ void main(void)
 	}
 
 	LOG_INF("Bluetooth initialized\n");
-	
+
 	/* STEP 6 - Start advertising */
 	err = bt_le_adv_start(BT_LE_ADV_NCONN, ad, ARRAY_SIZE(ad),
 			      sd, ARRAY_SIZE(sd));

--- a/lesson2/blefund_less2_exer1_solution/src/main.c
+++ b/lesson2/blefund_less2_exer1_solution/src/main.c
@@ -37,7 +37,7 @@ static unsigned char url_data[] ={0x17,'/','/','a','c','a','d','e','m','y','.',
 
 /* STEP 4.2.1 - Declare the scan response packet */
 static const struct bt_data sd[] = {
-	/* 4.2.3 Include the URL data in the scan response packet*/
+	/* 4.2.3 Include the URL data in the scan response packet */
 	BT_DATA(BT_DATA_URI, url_data,sizeof(url_data)),
 };
 

--- a/lesson2/blefund_less2_exer1_solution/src/main.c
+++ b/lesson2/blefund_less2_exer1_solution/src/main.c
@@ -37,7 +37,7 @@ static unsigned char url_data[] ={0x17,'/','/','a','c','a','d','e','m','y','.',
 
 /* STEP 4.2.1 - Declare the scan response packet */
 static const struct bt_data sd[] = {
-    /* 4.2.3 Include the URL data in the scan response packet*/
+	/* 4.2.3 Include the URL data in the scan response packet*/
 	BT_DATA(BT_DATA_URI, url_data,sizeof(url_data)),
 };
 

--- a/lesson2/blefund_less2_exer1_solution/src/main.c
+++ b/lesson2/blefund_less2_exer1_solution/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 /* STEP 3 - Include the header file of the Bluetooth LE stack */
@@ -15,11 +14,11 @@
 
 LOG_MODULE_REGISTER(Lesson2_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define RUN_LED_BLINK_INTERVAL 1000
 
 /* STEP 4.1.1 - Declare the advertising packet */
 static const struct bt_data ad[] = {
@@ -31,14 +30,14 @@ static const struct bt_data ad[] = {
 };
 
 /* STEP 4.2.2 - Declare the URL data to include in the scan response */
-static unsigned char url_data[] ={0x17,'/','/','a','c','a','d','e','m','y','.',
-                                 'n','o','r','d','i','c','s','e','m','i','.',
-                                 'c','o','m'};
+static unsigned char url_data[] = { 0x17, '/', '/', 'a', 'c', 'a', 'd', 'e', 'm',
+				    'y',  '.', 'n', 'o', 'r', 'd', 'i', 'c', 's',
+				    'e',  'm', 'i', '.', 'c', 'o', 'm' };
 
 /* STEP 4.2.1 - Declare the scan response packet */
 static const struct bt_data sd[] = {
 	/* 4.2.3 Include the URL data in the scan response packet */
-	BT_DATA(BT_DATA_URI, url_data,sizeof(url_data)),
+	BT_DATA(BT_DATA_URI, url_data, sizeof(url_data)),
 };
 
 void main(void)
@@ -63,8 +62,7 @@ void main(void)
 	LOG_INF("Bluetooth initialized\n");
 
 	/* STEP 6 - Start advertising */
-	err = bt_le_adv_start(BT_LE_ADV_NCONN, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_NCONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson2/blefund_less2_exer2/prj.conf
+++ b/lesson2/blefund_less2_exer2/prj.conf
@@ -7,13 +7,13 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
 CONFIG_BT=y
 CONFIG_BT_DEVICE_NAME="Nordic_Beacon"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson2/blefund_less2_exer2/src/main.c
+++ b/lesson2/blefund_less2_exer2/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -13,26 +12,24 @@
 
 /* STEP 2.1 - Declare the Company identifier (Company ID) */
 
-
 /* STEP 2.2 - Declare the structure for your custom data  */
 
-
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
 /* STEP 1 - Create an LE Advertising Parameters variable */
 
-
 /* STEP 2.3 - Define and initialize a variable of type adv_mfg_data_type */
 
-
-static unsigned char url_data[] ={0x17,'/','/','a','c','a','d','e','m','y','.','n','o','r','d','i','c','s','e','m','i','.','c','o','m'};
+static unsigned char url_data[] = { 0x17, '/', '/', 'a', 'c', 'a', 'd', 'e', 'm',
+				    'y',  '.', 'n', 'o', 'r', 'd', 'i', 'c', 's',
+				    'e',  'm', 'i', '.', 'c', 'o', 'm' };
 LOG_MODULE_REGISTER(Lesson2_Exercise2, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_NO_BREDR),
@@ -42,10 +39,9 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA(BT_DATA_URI, url_data,sizeof(url_data)),
+	BT_DATA(BT_DATA_URI, url_data, sizeof(url_data)),
 };
 /* STEP 5 - Add the definition of callback function and update the advertising data dynamically */
-
 
 /* STEP 4.1 - Define the initialization function of the buttons and setup interrupt.  */
 
@@ -63,7 +59,6 @@ void main(void)
 	}
 	/* STEP 4.2 - Setup buttons on your board  */
 
-
 	err = bt_enable(NULL);
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
@@ -72,8 +67,7 @@ void main(void)
 
 	LOG_INF("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson2/blefund_less2_exer2_solution/prj.conf
+++ b/lesson2/blefund_less2_exer2_solution/prj.conf
@@ -7,13 +7,13 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
 CONFIG_BT=y
 CONFIG_BT_DEVICE_NAME="Nordic_Beacon"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson2/blefund_less2_exer2_solution/src/main.c
+++ b/lesson2/blefund_less2_exer2_solution/src/main.c
@@ -23,7 +23,7 @@ typedef struct adv_mfg_data {
 
 /* STEP 1 - Create an LE Advertising Parameters variable */
 static struct bt_le_adv_param *adv_param =
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options specified */
 			800, /* Min Advertising Interval 500ms (800*0.625ms) */
 			801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
 			NULL); /* Set to NULL for undirected advertising */

--- a/lesson2/blefund_less2_exer2_solution/src/main.c
+++ b/lesson2/blefund_less2_exer2_solution/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -12,51 +11,53 @@
 #include <dk_buttons_and_leds.h>
 
 /* STEP 2.1 - Declare the Company identifier (Company ID) */
-#define COMPANY_ID_CODE            0x0059
+#define COMPANY_ID_CODE 0x0059
 
 /* STEP 2.2 - Declare the structure for your custom data  */
 typedef struct adv_mfg_data {
-	uint16_t company_code;	    /* Company Identifier Code. */
-	uint16_t number_press;      /* Number of times Button 1 is pressed */
+	uint16_t company_code; /* Company Identifier Code. */
+	uint16_t number_press; /* Number of times Button 1 is pressed */
 } adv_mfg_data_type;
 
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
 /* STEP 1 - Create an LE Advertising Parameters variable */
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
-		800, /* Min Advertising Interval 500ms (800*0.625ms) */
-		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
-		NULL); /* Set to NULL for undirected advertising */
+static struct bt_le_adv_param *adv_param =
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
+			800, /* Min Advertising Interval 500ms (800*0.625ms) */
+			801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+			NULL); /* Set to NULL for undirected advertising */
 
 /* STEP 2.3 - Define and initialize a variable of type adv_mfg_data_type */
-static adv_mfg_data_type adv_mfg_data = {COMPANY_ID_CODE,0x00};
+static adv_mfg_data_type adv_mfg_data = { COMPANY_ID_CODE, 0x00 };
 
-static unsigned char url_data[] ={0x17,'/','/','a','c','a','d','e','m','y','.','n','o','r','d','i','c','s','e','m','i','.','c','o','m'};
+static unsigned char url_data[] = { 0x17, '/', '/', 'a', 'c', 'a', 'd', 'e', 'm',
+				    'y',  '.', 'n', 'o', 'r', 'd', 'i', 'c', 's',
+				    'e',  'm', 'i', '.', 'c', 'o', 'm' };
 LOG_MODULE_REGISTER(Lesson2_Exercise2, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_NO_BREDR),
 	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
 	/* STEP 3 - Include the Manufacturer Specific Data in the advertising packet. */
-	BT_DATA(BT_DATA_MANUFACTURER_DATA,(unsigned char *)&adv_mfg_data, sizeof(adv_mfg_data)),
+	BT_DATA(BT_DATA_MANUFACTURER_DATA, (unsigned char *)&adv_mfg_data, sizeof(adv_mfg_data)),
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA(BT_DATA_URI, url_data,sizeof(url_data)),
+	BT_DATA(BT_DATA_URI, url_data, sizeof(url_data)),
 };
 /* STEP 5 - Add the definition of callback function and update the advertising data dynamically */
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	if (has_changed & button_state & USER_BUTTON) {
-	adv_mfg_data.number_press += 1;
-	bt_le_adv_update_data(ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+		adv_mfg_data.number_press += 1;
+		bt_le_adv_update_data(ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	}
 }
 /* STEP 4.1 - Define the initialization function of the buttons and setup interrupt.  */
@@ -99,8 +100,7 @@ void main(void)
 
 	LOG_INF("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson2/blefund_less2_exer2_solution/src/main.c
+++ b/lesson2/blefund_less2_exer2_solution/src/main.c
@@ -17,16 +17,16 @@
 /* STEP 2.2 - Declare the structure for your custom data  */
 typedef struct adv_mfg_data {
 	uint16_t company_code;	    /* Company Identifier Code. */
-	uint16_t number_press;      /* Number of times Button 1 is pressed*/
+	uint16_t number_press;      /* Number of times Button 1 is pressed */
 } adv_mfg_data_type;
 
 #define USER_BUTTON             DK_BTN1_MSK
 
 /* STEP 1 - Create an LE Advertising Parameters variable */
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified*/
-		800, /*Min Advertising Interval 500ms (800*0.625ms) */
-		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-		NULL); /* Set to NULL for undirected advertising*/
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
+		800, /* Min Advertising Interval 500ms (800*0.625ms) */
+		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+		NULL); /* Set to NULL for undirected advertising */
 
 /* STEP 2.3 - Define and initialize a variable of type adv_mfg_data_type */
 static adv_mfg_data_type adv_mfg_data = {COMPANY_ID_CODE,0x00};

--- a/lesson2/blefund_less2_exer2_solution/src/main.c
+++ b/lesson2/blefund_less2_exer2_solution/src/main.c
@@ -24,9 +24,9 @@ typedef struct adv_mfg_data {
 
 /* STEP 1 - Create an LE Advertising Parameters variable */
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified*/
-                800, /*Min Advertising Interval 500ms (800*0.625ms) */
-                801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-                NULL); /* Set to NULL for undirected advertising*/
+		800, /*Min Advertising Interval 500ms (800*0.625ms) */
+		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
+		NULL); /* Set to NULL for undirected advertising*/
 
 /* STEP 2.3 - Define and initialize a variable of type adv_mfg_data_type */
 static adv_mfg_data_type adv_mfg_data = {COMPANY_ID_CODE,0x00};

--- a/lesson2/blefund_less2_exer3/prj.conf
+++ b/lesson2/blefund_less2_exer3/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -17,6 +17,6 @@ CONFIG_BT=y
 # STEP 2 - Change the Bluetooth LE device name to Nordic_Peripheral
 CONFIG_BT_DEVICE_NAME="Nordic_Beacon"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson2/blefund_less2_exer3/src/main.c
+++ b/lesson2/blefund_less2_exer3/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -15,22 +14,18 @@
 
 #include <dk_buttons_and_leds.h>
 
-
 /* STEP 5.1 - Create the advertising parameter for connectable advertising */
-
-
 
 LOG_MODULE_REGISTER(Lesson2_Exercise3, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	/* STEP 3.1 - Set the flags and populate the device name in the advertising packet */
-
 
 };
 
@@ -54,7 +49,6 @@ void main(void)
 
 	/* STEP 4.2 - Change the random static address */
 
-
 	err = bt_enable(NULL);
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
@@ -63,7 +57,6 @@ void main(void)
 
 	LOG_INF("Bluetooth initialized\n");
 	/* STEP 5.2 - Start advertising */
-
 
 	LOG_INF("Advertising successfully started\n");
 

--- a/lesson2/blefund_less2_exer3/src/main.c
+++ b/lesson2/blefund_less2_exer3/src/main.c
@@ -60,7 +60,7 @@ void main(void)
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
- 
+
 	LOG_INF("Bluetooth initialized\n");
 	/* STEP 5.2 - Start advertising */
 

--- a/lesson2/blefund_less2_exer3/src/main.c
+++ b/lesson2/blefund_less2_exer3/src/main.c
@@ -9,9 +9,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gap.h>
-/*STEP 3.2.1 - Include the header file of the UUID helper macros and definitions */
+/* STEP 3.2.1 - Include the header file of the UUID helper macros and definitions */
 
-/*STEP 4.1 - Include the header file for managing Bluetooth LE addresses */
+/* STEP 4.1 - Include the header file for managing Bluetooth LE addresses */
 
 #include <dk_buttons_and_leds.h>
 

--- a/lesson2/blefund_less2_exer3_solution/prj.conf
+++ b/lesson2/blefund_less2_exer3_solution/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -17,6 +17,6 @@ CONFIG_BT_PERIPHERAL=y
 # STEP 2 - Change the Bluetooth LE device name to Nordic_Peripheral
 CONFIG_BT_DEVICE_NAME="Nordic_Peripheral"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson2/blefund_less2_exer3_solution/src/main.c
+++ b/lesson2/blefund_less2_exer3_solution/src/main.c
@@ -9,9 +9,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gap.h>
-/*STEP 3.2.1 - Include the header file of the UUID helper macros and definitions */
+/* STEP 3.2.1 - Include the header file of the UUID helper macros and definitions */
 #include <zephyr/bluetooth/uuid.h>
-/*STEP 4.1 - Include the header file for managing Bluetooth LE addresses */
+/* STEP 4.1 - Include the header file for managing Bluetooth LE addresses */
 #include <zephyr/bluetooth/addr.h>
 
 #include <dk_buttons_and_leds.h>
@@ -19,9 +19,9 @@
 
 /* STEP 5.1 - Create the advertising parameter for connectable advertising */
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /*Min Advertising Interval 500ms (800*0.625ms) */
-		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-		NULL); /* Set to NULL for undirected advertising*/
+		800, /* Min Advertising Interval 500ms (800*0.625ms) */
+		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson2_Exercise3, LOG_LEVEL_INF);

--- a/lesson2/blefund_less2_exer3_solution/src/main.c
+++ b/lesson2/blefund_less2_exer3_solution/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -16,21 +15,21 @@
 
 #include <dk_buttons_and_leds.h>
 
-
 /* STEP 5.1 - Create the advertising parameter for connectable advertising */
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /* Min Advertising Interval 500ms (800*0.625ms) */
-		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	800, /* Min Advertising Interval 500ms (800*0.625ms) */
+	801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson2_Exercise3, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	/* STEP 3.1 - Set the flags and populate the device name in the advertising packet */
@@ -41,7 +40,8 @@ static const struct bt_data ad[] = {
 
 static const struct bt_data sd[] = {
 	/* STEP 3.2.2 - Include the 16-bytes (128-Bits) UUID of the LBS service in the scan response packet */
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
 };
 
 void main(void)
@@ -77,8 +77,7 @@ void main(void)
 
 	LOG_INF("Bluetooth initialized\n");
 	/* STEP 5.2 - Start advertising */
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson2/blefund_less2_exer3_solution/src/main.c
+++ b/lesson2/blefund_less2_exer3_solution/src/main.c
@@ -74,7 +74,7 @@ void main(void)
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
- 
+
 	LOG_INF("Bluetooth initialized\n");
 	/* STEP 5.2 - Start advertising */
 	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),

--- a/lesson2/blefund_less2_exer3_solution/src/main.c
+++ b/lesson2/blefund_less2_exer3_solution/src/main.c
@@ -19,9 +19,9 @@
 
 /* STEP 5.1 - Create the advertising parameter for connectable advertising */
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                800, /*Min Advertising Interval 500ms (800*0.625ms) */
-                801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-                NULL); /* Set to NULL for undirected advertising*/
+		800, /*Min Advertising Interval 500ms (800*0.625ms) */
+		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson2_Exercise3, LOG_LEVEL_INF);
@@ -58,16 +58,16 @@ void main(void)
 	}
 
 	/* STEP 4.2 - Change the random static address */
-    bt_addr_le_t addr;
-    err = bt_addr_le_from_str("FF:EE:DD:CC:BB:AA", "random", &addr);
-    if (err) {
-        printk("Invalid BT address (err %d)\n", err);
-    }
+	bt_addr_le_t addr;
+	err = bt_addr_le_from_str("FF:EE:DD:CC:BB:AA", "random", &addr);
+	if (err) {
+		printk("Invalid BT address (err %d)\n", err);
+	}
 
-    err = bt_id_create(&addr, NULL);
-    if (err < 0) {
-        printk("Creating new ID failed (err %d)\n", err);
-    }
+	err = bt_id_create(&addr, NULL);
+	if (err < 0) {
+		printk("Creating new ID failed (err %d)\n", err);
+	}
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/lesson3/blefund_less3_exer1/prj.conf
+++ b/lesson3/blefund_less3_exer1/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -18,6 +18,6 @@ CONFIG_BT_DEVICE_NAME="Nordic_Peripheral"
 # STEP 8.1 - Add the LBS Service
 
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson3/blefund_less3_exer1/src/main.c
+++ b/lesson3/blefund_less3_exer1/src/main.c
@@ -31,7 +31,7 @@ struct bt_conn *my_conn = NULL;
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
 		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
 		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising*/
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise1, LOG_LEVEL_INF);
@@ -62,7 +62,7 @@ static const struct bt_data sd[] = {
 static int init_button(void)
 {
 	int err=0;
-	/*STEP 8.4 - Complete the implementation of the init_button() function. */
+	/* STEP 8.4 - Complete the implementation of the init_button() function. */
 
 
 	return err;

--- a/lesson3/blefund_less3_exer1/src/main.c
+++ b/lesson3/blefund_less3_exer1/src/main.c
@@ -29,9 +29,9 @@ struct bt_conn *my_conn = NULL;
 
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-                BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-                NULL); /* Set to NULL for undirected advertising*/
+		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise1, LOG_LEVEL_INF);
@@ -61,11 +61,11 @@ static const struct bt_data sd[] = {
 
 static int init_button(void)
 {
-    int err=0;
+	int err=0;
 	/*STEP 8.4 - Complete the implementation of the init_button() function. */
 
 
-    return err;
+	return err;
 }
 
 void main(void)
@@ -87,7 +87,7 @@ void main(void)
 		return;
 	}
 
-    /* STEP 2.3 - Register our custom callbacks */
+	/* STEP 2.3 - Register our custom callbacks */
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/lesson3/blefund_less3_exer1/src/main.c
+++ b/lesson3/blefund_less3_exer1/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -16,30 +15,27 @@
 
 /* STEP 8.2 - Include the header file for the LED Button Service */
 
-
 #include <dk_buttons_and_leds.h>
 
-#define USER_BUTTON             DK_BTN1_MSK
-#define RUN_STATUS_LED          DK_LED1
+#define USER_BUTTON DK_BTN1_MSK
+#define RUN_STATUS_LED DK_LED1
 /* STEP 3.1 - Define an LED to show the connection status */
 
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_LED_BLINK_INTERVAL 1000
 
 struct bt_conn *my_conn = NULL;
 
-
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+	BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson3_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
-
-
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -47,23 +43,20 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
 };
 
 /* STEP 2.2 - Implement the callback functions */
 
-
 /* STEP 2.1 - Declare the connection_callback structure */
-
 
 /* STEP 8.3 - Send a notification using the LBS characteristic. */
 
-
 static int init_button(void)
 {
-	int err=0;
+	int err = 0;
 	/* STEP 8.4 - Complete the implementation of the init_button() function. */
-
 
 	return err;
 }
@@ -96,8 +89,7 @@ void main(void)
 	}
 
 	LOG_INF("Bluetooth initialized");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/lesson3/blefund_less3_exer1/src/main.c
+++ b/lesson3/blefund_less3_exer1/src/main.c
@@ -80,7 +80,7 @@ void main(void)
 		LOG_ERR("LEDs init failed (err %d)", err);
 		return;
 	}
-	
+
 	err = init_button();
 	if (err) {
 		LOG_INF("Button init failed (err %d)", err);

--- a/lesson3/blefund_less3_exer1_solution/prj.conf
+++ b/lesson3/blefund_less3_exer1_solution/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -19,6 +19,6 @@ CONFIG_BT_DEVICE_NAME="Nordic_Peripheral"
 CONFIG_BT_LBS=y
 CONFIG_BT_LBS_POLL_BUTTON=y
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson3/blefund_less3_exer1_solution/src/main.c
+++ b/lesson3/blefund_less3_exer1_solution/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -19,27 +18,25 @@
 
 #include <dk_buttons_and_leds.h>
 
-#define USER_BUTTON             DK_BTN1_MSK
-#define RUN_STATUS_LED          DK_LED1
+#define USER_BUTTON DK_BTN1_MSK
+#define RUN_STATUS_LED DK_LED1
 /* STEP 3.1 - Define an LED to show the connection status */
-#define CONNECTION_STATUS_LED   DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
+#define CONNECTION_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
 struct bt_conn *my_conn = NULL;
 
-
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+	BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson3_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
-
-
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -47,7 +44,8 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
 };
 
 /* STEP 2.2 - Implement the callback functions */
@@ -75,10 +73,9 @@ void on_disconnected(struct bt_conn *conn, uint8_t reason)
 
 /* STEP 2.1 - Declare the connection_callback structure */
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 };
-
 
 /* STEP 8.3 - Send a notification using the LBS characteristic. */
 static void button_changed(uint32_t button_state, uint32_t has_changed)
@@ -135,8 +132,7 @@ void main(void)
 	}
 
 	LOG_INF("Bluetooth initialized");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/lesson3/blefund_less3_exer1_solution/src/main.c
+++ b/lesson3/blefund_less3_exer1_solution/src/main.c
@@ -31,7 +31,7 @@ struct bt_conn *my_conn = NULL;
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
 		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
 		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising*/
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise1, LOG_LEVEL_INF);
@@ -97,7 +97,7 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 static int init_button(void)
 {
 	int err;
-	/*STEP 8.4 - Complete the implementation of the init_button() function. */
+	/* STEP 8.4 - Complete the implementation of the init_button() function. */
 	err = dk_buttons_init(button_changed);
 	if (err) {
 		LOG_INF("Cannot init buttons (err: %d)", err);

--- a/lesson3/blefund_less3_exer1_solution/src/main.c
+++ b/lesson3/blefund_less3_exer1_solution/src/main.c
@@ -118,7 +118,7 @@ void main(void)
 		LOG_ERR("LEDs init failed (err %d)", err);
 		return;
 	}
-	
+
 	err = init_button();
 	if (err) {
 		LOG_INF("Button init failed (err %d)", err);

--- a/lesson3/blefund_less3_exer1_solution/src/main.c
+++ b/lesson3/blefund_less3_exer1_solution/src/main.c
@@ -29,9 +29,9 @@ struct bt_conn *my_conn = NULL;
 
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-                BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-                NULL); /* Set to NULL for undirected advertising*/
+		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise1, LOG_LEVEL_INF);
@@ -53,30 +53,30 @@ static const struct bt_data sd[] = {
 /* STEP 2.2 - Implement the callback functions */
 void on_connected(struct bt_conn *conn, uint8_t err)
 {
-    if (err) {
-        LOG_ERR("Connection error %d", err);
-        return;
-    }
-    LOG_INF("Connected");
-    my_conn = bt_conn_ref(conn);
+	if (err) {
+		LOG_ERR("Connection error %d", err);
+		return;
+	}
+	LOG_INF("Connected");
+	my_conn = bt_conn_ref(conn);
 
 	/* STEP 3.2  Turn the connection status LED on */
-    dk_set_led(CONNECTION_STATUS_LED, 1);
+	dk_set_led(CONNECTION_STATUS_LED, 1);
 }
 
 void on_disconnected(struct bt_conn *conn, uint8_t reason)
 {
-    LOG_INF("Disconnected. Reason %d", reason);
-    bt_conn_unref(my_conn);
+	LOG_INF("Disconnected. Reason %d", reason);
+	bt_conn_unref(my_conn);
 
 	/* STEP 3.3  Turn the connection status LED off */
-    dk_set_led(CONNECTION_STATUS_LED, 0);
+	dk_set_led(CONNECTION_STATUS_LED, 0);
 }
 
 /* STEP 2.1 - Declare the connection_callback structure */
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
 };
 
 
@@ -84,26 +84,26 @@ struct bt_conn_cb connection_callbacks = {
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	int err;
-    if (has_changed & USER_BUTTON) {
-        LOG_INF("Button changed");
+	if (has_changed & USER_BUTTON) {
+		LOG_INF("Button changed");
 
-        err = bt_lbs_send_button_state(button_state ? true : false);
-        if (err) {
-            LOG_ERR("Couldn't send notification. err: %d", err);
-        }
-    }
+		err = bt_lbs_send_button_state(button_state ? true : false);
+		if (err) {
+			LOG_ERR("Couldn't send notification. err: %d", err);
+		}
+	}
 }
 
 static int init_button(void)
 {
-    int err;
-/*STEP 8.4 - Complete the implementation of the init_button() function. */
-    err = dk_buttons_init(button_changed);
-    if (err) {
-        LOG_INF("Cannot init buttons (err: %d)", err);
-    }
+	int err;
+	/*STEP 8.4 - Complete the implementation of the init_button() function. */
+	err = dk_buttons_init(button_changed);
+	if (err) {
+		LOG_INF("Cannot init buttons (err: %d)", err);
+	}
 
-    return err;
+	return err;
 }
 
 void main(void)
@@ -125,8 +125,8 @@ void main(void)
 		return;
 	}
 
-   /* STEP 2.3 - Register our custom callbacks */
-    bt_conn_cb_register(&connection_callbacks);
+	/* STEP 2.3 - Register our custom callbacks */
+	bt_conn_cb_register(&connection_callbacks);
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/lesson3/blefund_less3_exer2/prj.conf
+++ b/lesson3/blefund_less3_exer2/prj.conf
@@ -9,7 +9,7 @@ CONFIG_LOG=y
 
 CONFIG_MAIN_STACK_SIZE=4096
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Floating Point Unit
@@ -29,6 +29,6 @@ CONFIG_BT_GATT_CLIENT=y
 
 # STEP 12 - Update Data Length and MTU
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson3/blefund_less3_exer2/src/main.c
+++ b/lesson3/blefund_less3_exer2/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -15,15 +14,14 @@
 #include <zephyr/bluetooth/conn.h>
 #include <bluetooth/services/lbs.h>
 
-
 #include <dk_buttons_and_leds.h>
 
-
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+	BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
 struct bt_conn *my_conn = NULL;
@@ -32,17 +30,13 @@ struct bt_conn *my_conn = NULL;
 
 /* STEP 13.4 - Forward declaration of exchange_func(): */
 
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
-
-#define USER_BUTTON             DK_BTN1_MSK
-#define RUN_STATUS_LED          DK_LED1
-#define CONNECTION_STATUS_LED   DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
-
-
+#define USER_BUTTON DK_BTN1_MSK
+#define RUN_STATUS_LED DK_LED1
+#define CONNECTION_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -50,7 +44,8 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
 };
 
 /* STEP 7.1 - Define the function to update the connection's PHY */
@@ -71,12 +66,11 @@ void on_connected(struct bt_conn *conn, uint8_t err)
 	dk_set_led(CONNECTION_STATUS_LED, 1);
 	/* STEP 1.1 - Declare a structure to store the connection parameters */
 
-	 /* STEP 1.2 - Add the connection parameters to your log */
+	/* STEP 1.2 - Add the connection parameters to your log */
 
 	/* STEP 7.2 - Update the PHY mode */
 
 	/* STEP 13.5 - Update the data length and MTU */
-
 }
 
 void on_disconnected(struct bt_conn *conn, uint8_t reason)
@@ -93,8 +87,8 @@ void on_disconnected(struct bt_conn *conn, uint8_t reason)
 /* STEP 13.1 - Write a callback function to inform about updates in data length */
 
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 	/* STEP 4.1 - Add the callback for connection parameter updates */
 	/* STEP 8.3 - Add the callback for PHY mode updates */
 	/* STEP 13.2 - Add the callback for data length updates */
@@ -154,8 +148,7 @@ void main(void)
 	}
 
 	LOG_INF("Bluetooth initialized");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/lesson3/blefund_less3_exer2/src/main.c
+++ b/lesson3/blefund_less3_exer2/src/main.c
@@ -70,11 +70,11 @@ void on_connected(struct bt_conn *conn, uint8_t err)
     my_conn = bt_conn_ref(conn);
     dk_set_led(CONNECTION_STATUS_LED, 1);
     /* STEP 1.1 - Declare a structure to store the connection parameters */
-    
+
 	 /* STEP 1.2 - Add the connection parameters to your log */
 
 	/* STEP 7.2 - Update the PHY mode */
-	
+
    /* STEP 13.5 - Update the data length and MTU */
 
 }
@@ -138,7 +138,7 @@ void main(void)
 		LOG_ERR("LEDs init failed (err %d)", err);
 		return;
 	}
-	
+
 	err = init_button();
 	if (err) {
 		LOG_ERR("Button init failed (err %d)", err);

--- a/lesson3/blefund_less3_exer2/src/main.c
+++ b/lesson3/blefund_less3_exer2/src/main.c
@@ -20,9 +20,9 @@
 
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-                BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-                NULL); /* Set to NULL for undirected advertising*/
+		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
@@ -62,28 +62,28 @@ static const struct bt_data sd[] = {
 /* Callbacks */
 void on_connected(struct bt_conn *conn, uint8_t err)
 {
-    if (err) {
-        LOG_ERR("Connection error %d", err);
-        return;
-    }
-    LOG_INF("Connected");
-    my_conn = bt_conn_ref(conn);
-    dk_set_led(CONNECTION_STATUS_LED, 1);
-    /* STEP 1.1 - Declare a structure to store the connection parameters */
+	if (err) {
+		LOG_ERR("Connection error %d", err);
+		return;
+	}
+	LOG_INF("Connected");
+	my_conn = bt_conn_ref(conn);
+	dk_set_led(CONNECTION_STATUS_LED, 1);
+	/* STEP 1.1 - Declare a structure to store the connection parameters */
 
 	 /* STEP 1.2 - Add the connection parameters to your log */
 
 	/* STEP 7.2 - Update the PHY mode */
 
-   /* STEP 13.5 - Update the data length and MTU */
+	/* STEP 13.5 - Update the data length and MTU */
 
 }
 
 void on_disconnected(struct bt_conn *conn, uint8_t reason)
 {
-    LOG_INF("Disconnected. Reason %d", reason);
-    dk_set_led(CONNECTION_STATUS_LED, 0);
-    bt_conn_unref(my_conn);
+	LOG_INF("Disconnected. Reason %d", reason);
+	dk_set_led(CONNECTION_STATUS_LED, 0);
+	bt_conn_unref(my_conn);
 }
 
 /* STEP 4.2 - Add the callback for connection parameter updates */
@@ -93,25 +93,25 @@ void on_disconnected(struct bt_conn *conn, uint8_t reason)
 /* STEP 13.1 - Write a callback function to inform about updates in data length*/
 
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
-    /* STEP 4.1 - Add the callback for connection parameter updates */
-    /* STEP 8.3 - Add the callback for PHY mode updates */
-    /* STEP 13.2 - Add the callback for data length updates */
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
+	/* STEP 4.1 - Add the callback for connection parameter updates */
+	/* STEP 8.3 - Add the callback for PHY mode updates */
+	/* STEP 13.2 - Add the callback for data length updates */
 };
 
 /* STEP 13.3 - Implement callback function for MTU exchange */
 
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
-    int err;
-    if (has_changed & USER_BUTTON) {
-        LOG_INF("Button changed");
-        err = bt_lbs_send_button_state(button_state ? true : false);
-        if (err) {
-            LOG_ERR("Couldn't send notification. err: %d", err);
-        }
-    }
+	int err;
+	if (has_changed & USER_BUTTON) {
+		LOG_INF("Button changed");
+		err = bt_lbs_send_button_state(button_state ? true : false);
+		if (err) {
+			LOG_ERR("Couldn't send notification. err: %d", err);
+		}
+	}
 }
 
 static int init_button(void)
@@ -145,7 +145,7 @@ void main(void)
 		return;
 	}
 
-    bt_conn_cb_register(&connection_callbacks);
+	bt_conn_cb_register(&connection_callbacks);
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/lesson3/blefund_less3_exer2/src/main.c
+++ b/lesson3/blefund_less3_exer2/src/main.c
@@ -22,7 +22,7 @@
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
 		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
 		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising*/
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
@@ -90,7 +90,7 @@ void on_disconnected(struct bt_conn *conn, uint8_t reason)
 
 /* STEP 8.1 - Write a callback function to inform about updates in the PHY */
 
-/* STEP 13.1 - Write a callback function to inform about updates in data length*/
+/* STEP 13.1 - Write a callback function to inform about updates in data length */
 
 struct bt_conn_cb connection_callbacks = {
 	.connected              = on_connected,

--- a/lesson3/blefund_less3_exer2_solution/prj.conf
+++ b/lesson3/blefund_less3_exer2_solution/prj.conf
@@ -8,7 +8,7 @@
 CONFIG_LOG=y
 
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Floating Point Unit
@@ -39,7 +39,7 @@ CONFIG_BT_BUF_ACL_RX_SIZE=251
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_L2CAP_TX_MTU=247
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048
 CONFIG_BT_RX_STACK_SIZE=2048

--- a/lesson3/blefund_less3_exer2_solution/prj_nrf5340dk_nrf5340_cpuapp.conf
+++ b/lesson3/blefund_less3_exer2_solution/prj_nrf5340dk_nrf5340_cpuapp.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Floating Point Unit

--- a/lesson3/blefund_less3_exer2_solution/src/main.c
+++ b/lesson3/blefund_less3_exer2_solution/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -15,15 +14,14 @@
 #include <zephyr/bluetooth/conn.h>
 #include <bluetooth/services/lbs.h>
 
-
 #include <dk_buttons_and_leds.h>
 
-
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+	BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
 struct bt_conn *my_conn = NULL;
@@ -32,18 +30,16 @@ struct bt_conn *my_conn = NULL;
 static struct bt_gatt_exchange_params exchange_params;
 
 /* STEP 13.4 - forward declaration of exchange_func(): */
-static void exchange_func(struct bt_conn *conn, uint8_t att_err, struct bt_gatt_exchange_params *params);
+static void exchange_func(struct bt_conn *conn, uint8_t att_err,
+			  struct bt_gatt_exchange_params *params);
 
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
-
-#define USER_BUTTON             DK_BTN1_MSK
-#define RUN_STATUS_LED          DK_LED1
-#define CONNECTION_STATUS_LED   DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
-
-
+#define USER_BUTTON DK_BTN1_MSK
+#define RUN_STATUS_LED DK_LED1
+#define CONNECTION_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -51,7 +47,8 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
 };
 
 /* STEP 7.1 - Define the function to update the connection's PHY */
@@ -115,9 +112,10 @@ void on_connected(struct bt_conn *conn, uint8_t err)
 	}
 
 	/* STEP 1.2 - Add the connection parameters to your log */
-	double connection_interval = info.le.interval*1.25; // in ms
-	uint16_t supervision_timeout = info.le.timeout*10; // in ms
-	LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, info.le.latency, supervision_timeout);
+	double connection_interval = info.le.interval * 1.25; // in ms
+	uint16_t supervision_timeout = info.le.timeout * 10; // in ms
+	LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms",
+		connection_interval, info.le.latency, supervision_timeout);
 
 	/* STEP 7 - Update the PHY mode */
 	update_phy(my_conn);
@@ -134,11 +132,13 @@ void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 /* STEP 4.2 - Add the callback for connection parameter updates */
-void on_le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency, uint16_t timeout)
+void on_le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency,
+			 uint16_t timeout)
 {
-	double connection_interval = interval*1.25;         // in ms
-	uint16_t supervision_timeout = timeout*10;          // in ms
-	LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, latency, supervision_timeout);
+	double connection_interval = interval * 1.25; // in ms
+	uint16_t supervision_timeout = timeout * 10; // in ms
+	LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms",
+		connection_interval, latency, supervision_timeout);
 }
 
 /* STEP 8.1 - Write a callback function to inform about updates in the PHY */
@@ -147,33 +147,32 @@ void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
 	// PHY Updated
 	if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_1M) {
 		LOG_INF("PHY updated. New PHY: 1M");
-	}
-	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
+	} else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
 		LOG_INF("PHY updated. New PHY: 2M");
-	}
-	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
+	} else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
 		LOG_INF("PHY updated. New PHY: Long Range");
 	}
 }
 /* STEP 13.1 - Write a callback function to inform about updates in data length */
 void on_le_data_len_updated(struct bt_conn *conn, struct bt_conn_le_data_len_info *info)
 {
-	uint16_t tx_len     = info->tx_max_len;
-	uint16_t tx_time    = info->tx_max_time;
-	uint16_t rx_len     = info->rx_max_len;
-	uint16_t rx_time    = info->rx_max_time;
-	LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time, rx_time);
+	uint16_t tx_len = info->tx_max_len;
+	uint16_t tx_time = info->tx_max_time;
+	uint16_t rx_len = info->rx_max_len;
+	uint16_t rx_time = info->rx_max_time;
+	LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time,
+		rx_time);
 }
 
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 	/* STEP 4.1 - Add the callback for connection parameter updates */
-	.le_param_updated       = on_le_param_updated,
+	.le_param_updated = on_le_param_updated,
 	/* STEP 8.3 - Add the callback for PHY mode updates */
-	.le_phy_updated         = on_le_phy_updated,
+	.le_phy_updated = on_le_phy_updated,
 	/* STEP 13.2 - Add the callback for data length updates */
-	.le_data_len_updated    = on_le_data_len_updated,
+	.le_data_len_updated = on_le_data_len_updated,
 };
 
 /* STEP 13.3 - Implement callback function for MTU exchange */
@@ -182,7 +181,8 @@ static void exchange_func(struct bt_conn *conn, uint8_t att_err,
 {
 	LOG_INF("MTU exchange %s", att_err == 0 ? "successful" : "failed");
 	if (!att_err) {
-		uint16_t payload_mtu = bt_gatt_get_mtu(conn) - 3;   // 3 bytes used for Attribute headers.
+		uint16_t payload_mtu =
+			bt_gatt_get_mtu(conn) - 3; // 3 bytes used for Attribute headers.
 		LOG_INF("New MTU: %d bytes", payload_mtu);
 	}
 }
@@ -239,8 +239,7 @@ void main(void)
 	}
 
 	LOG_INF("Bluetooth initialized");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/lesson3/blefund_less3_exer2_solution/src/main.c
+++ b/lesson3/blefund_less3_exer2_solution/src/main.c
@@ -20,9 +20,9 @@
 
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-                BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-                NULL); /* Set to NULL for undirected advertising*/
+		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
@@ -57,123 +57,123 @@ static const struct bt_data sd[] = {
 /* STEP 7.1 - Define the function to update the connection's PHY */
 static void update_phy(struct bt_conn *conn)
 {
-    int err;
-    const struct bt_conn_le_phy_param preferred_phy = {
-        .options = BT_CONN_LE_PHY_OPT_NONE,
-        .pref_rx_phy = BT_GAP_LE_PHY_2M,
-        .pref_tx_phy = BT_GAP_LE_PHY_2M,
-    };
-    err = bt_conn_le_phy_update(conn, &preferred_phy);
-    if (err) {
-        LOG_ERR("bt_conn_le_phy_update() returned %d", err);
-    }
+	int err;
+	const struct bt_conn_le_phy_param preferred_phy = {
+		.options = BT_CONN_LE_PHY_OPT_NONE,
+		.pref_rx_phy = BT_GAP_LE_PHY_2M,
+		.pref_tx_phy = BT_GAP_LE_PHY_2M,
+	};
+	err = bt_conn_le_phy_update(conn, &preferred_phy);
+	if (err) {
+		LOG_ERR("bt_conn_le_phy_update() returned %d", err);
+	}
 }
 
 /* STEP 10 - Define the function to update the connection's data length */
 static void update_data_length(struct bt_conn *conn)
 {
-    int err;
-    struct bt_conn_le_data_len_param my_data_len = {
-        .tx_max_len = BT_GAP_DATA_LEN_MAX,
-        .tx_max_time = BT_GAP_DATA_TIME_MAX,
-    };
-    err = bt_conn_le_data_len_update(my_conn, &my_data_len);
-    if (err) {
-        LOG_ERR("data_len_update failed (err %d)", err);
-    }
+	int err;
+	struct bt_conn_le_data_len_param my_data_len = {
+		.tx_max_len = BT_GAP_DATA_LEN_MAX,
+		.tx_max_time = BT_GAP_DATA_TIME_MAX,
+	};
+	err = bt_conn_le_data_len_update(my_conn, &my_data_len);
+	if (err) {
+		LOG_ERR("data_len_update failed (err %d)", err);
+	}
 }
 
 /* STEP 11.1 - Define the function to update the connection's MTU */
 static void update_mtu(struct bt_conn *conn)
 {
-    int err;
-    exchange_params.func = exchange_func;
+	int err;
+	exchange_params.func = exchange_func;
 
-    err = bt_gatt_exchange_mtu(conn, &exchange_params);
-    if (err) {
-        LOG_ERR("bt_gatt_exchange_mtu failed (err %d)", err);
-    }
+	err = bt_gatt_exchange_mtu(conn, &exchange_params);
+	if (err) {
+		LOG_ERR("bt_gatt_exchange_mtu failed (err %d)", err);
+	}
 }
 
 /* Callbacks */
 void on_connected(struct bt_conn *conn, uint8_t err)
 {
-    if (err) {
-        LOG_ERR("Connection error %d", err);
-        return;
-    }
-    LOG_INF("Connected");
-    my_conn = bt_conn_ref(conn);
-    dk_set_led(CONNECTION_STATUS_LED, 1);
+	if (err) {
+		LOG_ERR("Connection error %d", err);
+		return;
+	}
+	LOG_INF("Connected");
+	my_conn = bt_conn_ref(conn);
+	dk_set_led(CONNECTION_STATUS_LED, 1);
 
-    /* STEP 1.1 - Declare a structure to store the connection parameters */
-    struct bt_conn_info info;
-    err = bt_conn_get_info(conn, &info);
-    if (err) {
-        LOG_ERR("bt_conn_get_info() returned %d", err);
-        return;
-    }
+	/* STEP 1.1 - Declare a structure to store the connection parameters */
+	struct bt_conn_info info;
+	err = bt_conn_get_info(conn, &info);
+	if (err) {
+		LOG_ERR("bt_conn_get_info() returned %d", err);
+		return;
+	}
 
-    /* STEP 1.2 - Add the connection parameters to your log */
-    double connection_interval = info.le.interval*1.25; // in ms
-    uint16_t supervision_timeout = info.le.timeout*10; // in ms
-    LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, info.le.latency, supervision_timeout);
+	/* STEP 1.2 - Add the connection parameters to your log */
+	double connection_interval = info.le.interval*1.25; // in ms
+	uint16_t supervision_timeout = info.le.timeout*10; // in ms
+	LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, info.le.latency, supervision_timeout);
 
-    /* STEP 7 - Update the PHY mode */
-    update_phy(my_conn);
-    /* STEP 13.5 - Update the data length and MTU */
-    update_data_length(my_conn);
-    update_mtu(my_conn);
+	/* STEP 7 - Update the PHY mode */
+	update_phy(my_conn);
+	/* STEP 13.5 - Update the data length and MTU */
+	update_data_length(my_conn);
+	update_mtu(my_conn);
 }
 
 void on_disconnected(struct bt_conn *conn, uint8_t reason)
 {
-    LOG_INF("Disconnected. Reason %d", reason);
-    dk_set_led(CONNECTION_STATUS_LED, 0);
-    bt_conn_unref(my_conn);
+	LOG_INF("Disconnected. Reason %d", reason);
+	dk_set_led(CONNECTION_STATUS_LED, 0);
+	bt_conn_unref(my_conn);
 }
 
 /* STEP 4.2 - Add the callback for connection parameter updates */
 void on_le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency, uint16_t timeout)
 {
-    double connection_interval = interval*1.25;         // in ms
-    uint16_t supervision_timeout = timeout*10;          // in ms
-    LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, latency, supervision_timeout);
+	double connection_interval = interval*1.25;         // in ms
+	uint16_t supervision_timeout = timeout*10;          // in ms
+	LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, latency, supervision_timeout);
 }
 
 /* STEP 8.1 - Write a callback function to inform about updates in the PHY */
 void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
 {
-    // PHY Updated
-    if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_1M) {
-        LOG_INF("PHY updated. New PHY: 1M");
-    }
-    else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
-        LOG_INF("PHY updated. New PHY: 2M");
-    }
-    else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
-        LOG_INF("PHY updated. New PHY: Long Range");
-    }
+	// PHY Updated
+	if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_1M) {
+		LOG_INF("PHY updated. New PHY: 1M");
+	}
+	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
+		LOG_INF("PHY updated. New PHY: 2M");
+	}
+	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
+		LOG_INF("PHY updated. New PHY: Long Range");
+	}
 }
 /* STEP 13.1 - Write a callback function to inform about updates in data length*/
 void on_le_data_len_updated(struct bt_conn *conn, struct bt_conn_le_data_len_info *info)
 {
-    uint16_t tx_len     = info->tx_max_len;
-    uint16_t tx_time    = info->tx_max_time;
-    uint16_t rx_len     = info->rx_max_len;
-    uint16_t rx_time    = info->rx_max_time;
-    LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time, rx_time);
+	uint16_t tx_len     = info->tx_max_len;
+	uint16_t tx_time    = info->tx_max_time;
+	uint16_t rx_len     = info->rx_max_len;
+	uint16_t rx_time    = info->rx_max_time;
+	LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time, rx_time);
 }
 
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
-    /* STEP 4.1 - Add the callback for connection parameter updates */
-    .le_param_updated       = on_le_param_updated,
-    /* STEP 8.3 - Add the callback for PHY mode updates */
-    .le_phy_updated         = on_le_phy_updated,
-    /* STEP 13.2 - Add the callback for data length updates */
-    .le_data_len_updated    = on_le_data_len_updated,
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
+	/* STEP 4.1 - Add the callback for connection parameter updates */
+	.le_param_updated       = on_le_param_updated,
+	/* STEP 8.3 - Add the callback for PHY mode updates */
+	.le_phy_updated         = on_le_phy_updated,
+	/* STEP 13.2 - Add the callback for data length updates */
+	.le_data_len_updated    = on_le_data_len_updated,
 };
 
 /* STEP 13.3 - Implement callback function for MTU exchange */
@@ -181,22 +181,22 @@ static void exchange_func(struct bt_conn *conn, uint8_t att_err,
 			  struct bt_gatt_exchange_params *params)
 {
 	LOG_INF("MTU exchange %s", att_err == 0 ? "successful" : "failed");
-    if (!att_err) {
-        uint16_t payload_mtu = bt_gatt_get_mtu(conn) - 3;   // 3 bytes used for Attribute headers.
-        LOG_INF("New MTU: %d bytes", payload_mtu);
-    }
+	if (!att_err) {
+		uint16_t payload_mtu = bt_gatt_get_mtu(conn) - 3;   // 3 bytes used for Attribute headers.
+		LOG_INF("New MTU: %d bytes", payload_mtu);
+	}
 }
 
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
-    int err;
-    if (has_changed & USER_BUTTON) {
-        LOG_INF("Button changed");
-        err = bt_lbs_send_button_state(button_state ? true : false);
-        if (err) {
-            LOG_ERR("Couldn't send notification. err: %d", err);
-        }
-    }
+	int err;
+	if (has_changed & USER_BUTTON) {
+		LOG_INF("Button changed");
+		err = bt_lbs_send_button_state(button_state ? true : false);
+		if (err) {
+			LOG_ERR("Couldn't send notification. err: %d", err);
+		}
+	}
 }
 
 static int init_button(void)
@@ -230,7 +230,7 @@ void main(void)
 		return;
 	}
 
-    bt_conn_cb_register(&connection_callbacks);
+	bt_conn_cb_register(&connection_callbacks);
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/lesson3/blefund_less3_exer2_solution/src/main.c
+++ b/lesson3/blefund_less3_exer2_solution/src/main.c
@@ -158,7 +158,7 @@ void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
 /* STEP 13.1 - Write a callback function to inform about updates in data length*/
 void on_le_data_len_updated(struct bt_conn *conn, struct bt_conn_le_data_len_info *info)
 {
-    uint16_t tx_len     = info->tx_max_len; 
+    uint16_t tx_len     = info->tx_max_len;
     uint16_t tx_time    = info->tx_max_time;
     uint16_t rx_len     = info->rx_max_len;
     uint16_t rx_time    = info->rx_max_time;
@@ -223,7 +223,7 @@ void main(void)
 		LOG_ERR("LEDs init failed (err %d)", err);
 		return;
 	}
-	
+
 	err = init_button();
 	if (err) {
 		LOG_ERR("Button init failed (err %d)", err);

--- a/lesson3/blefund_less3_exer2_solution/src/main.c
+++ b/lesson3/blefund_less3_exer2_solution/src/main.c
@@ -22,7 +22,7 @@
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
 		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
 		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising*/
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
@@ -155,7 +155,7 @@ void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
 		LOG_INF("PHY updated. New PHY: Long Range");
 	}
 }
-/* STEP 13.1 - Write a callback function to inform about updates in data length*/
+/* STEP 13.1 - Write a callback function to inform about updates in data length */
 void on_le_data_len_updated(struct bt_conn *conn, struct bt_conn_le_data_len_info *info)
 {
 	uint16_t tx_len     = info->tx_max_len;

--- a/lesson4/blefund_less4_exer1/prj.conf
+++ b/lesson4/blefund_less4_exer1/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -16,6 +16,6 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="MY_LBS1"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson4/blefund_less4_exer1/src/main.c
+++ b/lesson4/blefund_less4_exer1/src/main.c
@@ -18,9 +18,9 @@
 
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /*Min Advertising Interval 500ms (800*0.625ms) */
-		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-		NULL); /* Set to NULL for undirected advertising*/
+		800, /* Min Advertising Interval 500ms (800*0.625ms) */
+		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise1, LOG_LEVEL_INF);
@@ -51,13 +51,13 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_LBS_VAL),
 };
 
-/* STEP 8.2 - Define the application callback function for controlling the LED*/
+/* STEP 8.2 - Define the application callback function for controlling the LED */
 
 
 /* STEP 9.2 - Define the application callback function for reading the state of the button */
 
 
-/* STEP 10 - Declare a varaible app_callbacks of type my_lbs_cb and initiate its members to the applications call back functions we developed in steps 8.2 and 9.2 .*/
+/* STEP 10 - Declare a varaible app_callbacks of type my_lbs_cb and initiate its members to the applications call back functions we developed in steps 8.2 and 9.2. */
 
 
 static void button_changed(uint32_t button_state, uint32_t has_changed)

--- a/lesson4/blefund_less4_exer1/src/main.c
+++ b/lesson4/blefund_less4_exer1/src/main.c
@@ -88,7 +88,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 
 struct bt_conn_cb connection_callbacks = {
     .connected              = on_connected,
-    .disconnected           = on_disconnected,  
+    .disconnected           = on_disconnected,
 };
 
 static int init_button(void)

--- a/lesson4/blefund_less4_exer1/src/main.c
+++ b/lesson4/blefund_less4_exer1/src/main.c
@@ -18,9 +18,9 @@
 
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                800, /*Min Advertising Interval 500ms (800*0.625ms) */
-                801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-                NULL); /* Set to NULL for undirected advertising*/
+		800, /*Min Advertising Interval 500ms (800*0.625ms) */
+		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise1, LOG_LEVEL_INF);
@@ -87,8 +87,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
 };
 
 static int init_button(void)
@@ -127,7 +127,7 @@ void main(void)
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-    bt_conn_cb_register(&connection_callbacks);
+	bt_conn_cb_register(&connection_callbacks);
 
 	/* STEP 11 - Pass your application callback functions stored in app_callbacks to the MY LBS service */
 

--- a/lesson4/blefund_less4_exer1/src/main.c
+++ b/lesson4/blefund_less4_exer1/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -12,32 +11,29 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>
 
-
 #include <dk_buttons_and_leds.h>
 /* STEP 7 - Include the header file of MY LBS customer service */
 
-
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /* Min Advertising Interval 500ms (800*0.625ms) */
-		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	800, /* Min Advertising Interval 500ms (800*0.625ms) */
+	801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson4_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
 
 /* STEP 8.1 - Specify the LED to control */
 
-
 /* STEP 9.1 - Specify the button to monitor */
 
-
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static bool app_button_state;
 
@@ -53,12 +49,9 @@ static const struct bt_data sd[] = {
 
 /* STEP 8.2 - Define the application callback function for controlling the LED */
 
-
 /* STEP 9.2 - Define the application callback function for reading the state of the button */
 
-
 /* STEP 10 - Declare a varaible app_callbacks of type my_lbs_cb and initiate its members to the applications call back functions we developed in steps 8.2 and 9.2. */
-
 
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
@@ -87,8 +80,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 };
 
 static int init_button(void)
@@ -131,10 +124,8 @@ void main(void)
 
 	/* STEP 11 - Pass your application callback functions stored in app_callbacks to the MY LBS service */
 
-
 	LOG_INF("Bluetooth initialized\n");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson4/blefund_less4_exer1/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer1/src/my_lbs.c
@@ -35,7 +35,7 @@ static struct my_lbs_cb       lbs_cb;
 /* STEP 6 - Implement the write callback function of the LED characteristic */
 
 
-/* STEP 5 - Implement the read callback function of the Button characteristic*/
+/* STEP 5 - Implement the read callback function of the Button characteristic */
 
 
 

--- a/lesson4/blefund_less4_exer1/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer1/src/my_lbs.c
@@ -28,30 +28,23 @@
 
 LOG_MODULE_DECLARE(Lesson4_Exercise1);
 
-
-static bool                   button_state;
-static struct my_lbs_cb       lbs_cb;
+static bool button_state;
+static struct my_lbs_cb lbs_cb;
 
 /* STEP 6 - Implement the write callback function of the LED characteristic */
 
-
 /* STEP 5 - Implement the read callback function of the Button characteristic */
-
-
 
 /* LED Button Service Declaration */
 /* STEP 2 - Create and add the MY LBS service to the Bluetooth LE stack */
-
 
 /* A function to register application callbacks for the LED and Button characteristics  */
 int my_lbs_init(struct my_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
 	return 0;
 }
-
-

--- a/lesson4/blefund_less4_exer1/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer1/src/my_lbs.h
@@ -21,7 +21,6 @@ extern "C" {
 
 /* STEP 1 - Define the 128 bit UUIDs for the GATT service and its characteristics in */
 
-
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
 
@@ -31,7 +30,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct my_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };
@@ -50,7 +49,6 @@ struct my_lbs_cb {
  *           Otherwise, a (negative) error code is returned.
  */
 int my_lbs_init(struct my_lbs_cb *callbacks);
-
 
 #ifdef __cplusplus
 }

--- a/lesson4/blefund_less4_exer1/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer1/src/my_lbs.h
@@ -39,7 +39,7 @@ struct my_lbs_cb {
 /** @brief Initialize the LBS Service.
  *
  * This function registers application callback functions with the My LBS
- * Service 
+ * Service
  *
  * @param[in] callbacks Struct containing pointers to callback functions
  *			used by the service. This pointer can be NULL

--- a/lesson4/blefund_less4_exer1_solution/prj.conf
+++ b/lesson4/blefund_less4_exer1_solution/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -16,6 +16,6 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="MY_LBS1"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson4/blefund_less4_exer1_solution/src/main.c
+++ b/lesson4/blefund_less4_exer1_solution/src/main.c
@@ -18,9 +18,9 @@
 #include "my_lbs.h"
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                800, /*Min Advertising Interval 500ms (800*0.625ms) */
-                801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-                NULL); /* Set to NULL for undirected advertising*/
+		800, /*Min Advertising Interval 500ms (800*0.625ms) */
+		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise1, LOG_LEVEL_INF);
@@ -96,8 +96,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
 };
 
 static int init_button(void)
@@ -136,7 +136,7 @@ void main(void)
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-    bt_conn_cb_register(&connection_callbacks);
+	bt_conn_cb_register(&connection_callbacks);
 
 	/* STEP 11 - Pass your application callback functions stored in app_callbacks to the MY LBS service */
 	err = my_lbs_init(&app_callbacks);

--- a/lesson4/blefund_less4_exer1_solution/src/main.c
+++ b/lesson4/blefund_less4_exer1_solution/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -12,32 +11,32 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>
 
-
 #include <dk_buttons_and_leds.h>
 /* STEP 7 - Include the header file of MY LBS customer service */
 #include "my_lbs.h"
 
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /* Min Advertising Interval 500ms (800*0.625ms) */
-		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	800, /* Min Advertising Interval 500ms (800*0.625ms) */
+	801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson4_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
 
 /* STEP 8.1 - Specify the LED to control */
-#define USER_LED                DK_LED3
+#define USER_LED DK_LED3
 
 /* STEP 9.1 - Specify the button to monitor */
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static bool app_button_state;
 
@@ -65,7 +64,7 @@ static bool app_button_cb(void)
 
 /* STEP 10 - Declare a varaible app_callbacks of type my_lbs_cb and initiate its members to the applications call back functions we developed in steps 8.2 and 9.2. */
 static struct my_lbs_cb app_callbacks = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -96,8 +95,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 };
 
 static int init_button(void)
@@ -145,8 +144,7 @@ void main(void)
 		return;
 	}
 	LOG_INF("Bluetooth initialized\n");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson4/blefund_less4_exer1_solution/src/main.c
+++ b/lesson4/blefund_less4_exer1_solution/src/main.c
@@ -18,9 +18,9 @@
 #include "my_lbs.h"
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /*Min Advertising Interval 500ms (800*0.625ms) */
-		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-		NULL); /* Set to NULL for undirected advertising*/
+		800, /* Min Advertising Interval 500ms (800*0.625ms) */
+		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise1, LOG_LEVEL_INF);
@@ -51,7 +51,7 @@ static const struct bt_data sd[] = {
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_LBS_VAL),
 };
 
-/* STEP 8.2 - Define the application callback function for controlling the LED*/
+/* STEP 8.2 - Define the application callback function for controlling the LED */
 static void app_led_cb(bool led_state)
 {
 	dk_set_led(USER_LED, led_state);
@@ -63,7 +63,7 @@ static bool app_button_cb(void)
 	return app_button_state;
 }
 
-/* STEP 10 - Declare a varaible app_callbacks of type my_lbs_cb and initiate its members to the applications call back functions we developed in steps 8.2 and 9.2 .*/
+/* STEP 10 - Declare a varaible app_callbacks of type my_lbs_cb and initiate its members to the applications call back functions we developed in steps 8.2 and 9.2. */
 static struct my_lbs_cb app_callbacks = {
 	.led_cb    = app_led_cb,
 	.button_cb = app_button_cb,

--- a/lesson4/blefund_less4_exer1_solution/src/main.c
+++ b/lesson4/blefund_less4_exer1_solution/src/main.c
@@ -97,7 +97,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 
 struct bt_conn_cb connection_callbacks = {
     .connected              = on_connected,
-    .disconnected           = on_disconnected,  
+    .disconnected           = on_disconnected,
 };
 
 static int init_button(void)

--- a/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
@@ -52,7 +52,7 @@ static ssize_t write_led(struct bt_conn *conn,
 	}
 
 	if (lbs_cb.led_cb) {
-		//Read the received value 
+		//Read the received value
 		uint8_t val = *((uint8_t *)buf);
 
 		if (val == 0x00 || val == 0x01) {
@@ -105,7 +105,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 			       BT_GATT_CHRC_WRITE,
 			       BT_GATT_PERM_WRITE,
 			       NULL, write_led, NULL),
- 
+
 );
 /* A function to register application callbacks for the LED and Button characteristics  */
 int my_lbs_init(struct my_lbs_cb *callbacks)

--- a/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
@@ -69,10 +69,10 @@ static ssize_t write_led(struct bt_conn *conn,
 
 /* STEP 5 - Implement the read callback function of the Button characteristic*/
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	//get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;

--- a/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
@@ -52,11 +52,11 @@ static ssize_t write_led(struct bt_conn *conn,
 	}
 
 	if (lbs_cb.led_cb) {
-		//Read the received value
+		// Read the received value
 		uint8_t val = *((uint8_t *)buf);
 
 		if (val == 0x00 || val == 0x01) {
-			//Call the application callback function to update the LED state
+			// Call the application callback function to update the LED state
 			lbs_cb.led_cb(val ? true : false);
 		} else {
 			LOG_DBG("Write led: Incorrect value");
@@ -67,14 +67,14 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 
-/* STEP 5 - Implement the read callback function of the Button characteristic*/
+/* STEP 5 - Implement the read callback function of the Button characteristic */
 static ssize_t read_button(struct bt_conn *conn,
 			   const struct bt_gatt_attr *attr,
 			   void *buf,
 			   uint16_t len,
 			   uint16_t offset)
 {
-	//get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
+	// get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;
 
 	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,

--- a/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer1_solution/src/my_lbs.c
@@ -28,18 +28,14 @@
 
 LOG_MODULE_DECLARE(Lesson4_Exercise1);
 
-
-static bool                   button_state;
-static struct my_lbs_cb       lbs_cb;
+static bool button_state;
+static struct my_lbs_cb lbs_cb;
 
 /* STEP 6 - Implement the write callback function of the LED characteristic */
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -68,54 +64,41 @@ static ssize_t write_led(struct bt_conn *conn,
 }
 
 /* STEP 5 - Implement the read callback function of the Button characteristic */
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	// get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		// Call the application callback function to update the get the current value of the button
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
 /* STEP 2 - Create and add the MY LBS service to the Bluetooth LE stack */
-BT_GATT_SERVICE_DEFINE(my_lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-/* STEP 3 - Create and add the Button characteristic */
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ ,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-/* STEP 4 - Create and add the LED characteristic. */
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_WRITE,
-			       NULL, write_led, NULL),
+BT_GATT_SERVICE_DEFINE(my_lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+		       /* STEP 3 - Create and add the Button characteristic */
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON, BT_GATT_CHRC_READ,
+					      BT_GATT_PERM_READ, read_button, NULL, &button_state),
+		       /* STEP 4 - Create and add the LED characteristic. */
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE,
+					      BT_GATT_PERM_WRITE, NULL, write_led, NULL),
 
 );
 /* A function to register application callbacks for the LED and Button characteristics  */
 int my_lbs_init(struct my_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
 	return 0;
 }
-
-

--- a/lesson4/blefund_less4_exer1_solution/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer1_solution/src/my_lbs.h
@@ -21,21 +21,18 @@ extern "C" {
 
 /* STEP 1 - Define the 128 bit UUIDs for the GATT service and its characteristics in */
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -46,7 +43,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct my_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };
@@ -65,7 +62,6 @@ struct my_lbs_cb {
  *           Otherwise, a (negative) error code is returned.
  */
 int my_lbs_init(struct my_lbs_cb *callbacks);
-
 
 #ifdef __cplusplus
 }

--- a/lesson4/blefund_less4_exer1_solution/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer1_solution/src/my_lbs.h
@@ -54,7 +54,7 @@ struct my_lbs_cb {
 /** @brief Initialize the LBS Service.
  *
  * This function registers application callback functions with the My LBS
- * Service 
+ * Service
  *
  * @param[in] callbacks Struct containing pointers to callback functions
  *			used by the service. This pointer can be NULL

--- a/lesson4/blefund_less4_exer2/prj.conf
+++ b/lesson4/blefund_less4_exer2/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -15,6 +15,6 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="MY_LBS2"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson4/blefund_less4_exer2/src/main.c
+++ b/lesson4/blefund_less4_exer2/src/main.c
@@ -15,9 +15,9 @@
 #include "my_lbs.h"
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /*Min Advertising Interval 500ms (800*0.625ms) */
-		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-		NULL); /* Set to NULL for undirected advertising*/
+		800, /* Min Advertising Interval 500ms (800*0.625ms) */
+		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise2, LOG_LEVEL_INF);
@@ -78,7 +78,7 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	if (has_changed & USER_BUTTON) {
 		uint32_t user_button_state = button_state & USER_BUTTON;
-		/*STEP 6 - Send indication on a button press*/
+		/* STEP 6 - Send indication on a button press */
 
 		app_button_state = user_button_state ? true : false;
 	}

--- a/lesson4/blefund_less4_exer2/src/main.c
+++ b/lesson4/blefund_less4_exer2/src/main.c
@@ -78,8 +78,8 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	if (has_changed & USER_BUTTON) {
 		uint32_t user_button_state = button_state & USER_BUTTON;
-		/*STEP 6 - Send indication on a button press*/ 
-		
+		/*STEP 6 - Send indication on a button press*/
+
 		app_button_state = user_button_state ? true : false;
 	}
 }
@@ -104,7 +104,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 
 struct bt_conn_cb connection_callbacks = {
     .connected              = on_connected,
-    .disconnected           = on_disconnected,  
+    .disconnected           = on_disconnected,
 };
 
 static int init_button(void)

--- a/lesson4/blefund_less4_exer2/src/main.c
+++ b/lesson4/blefund_less4_exer2/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -14,33 +13,31 @@
 #include <dk_buttons_and_leds.h>
 #include "my_lbs.h"
 
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /* Min Advertising Interval 500ms (800*0.625ms) */
-		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	800, /* Min Advertising Interval 500ms (800*0.625ms) */
+	801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson4_Exercise2, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define USER_LED                DK_LED3
-#define USER_BUTTON             DK_BTN1_MSK
-
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define USER_LED DK_LED3
+#define USER_BUTTON DK_BTN1_MSK
 
 #define STACKSIZE 1024
 #define PRIORITY 7
 
-
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_LED_BLINK_INTERVAL 1000
 /* STEP 17 - Define the interval at which you want to send data at */
 
 static bool app_button_state;
 /* STEP 15 - Define the data you want to stream over Bluetooth LE */
-
 
 static bool app_button_state;
 
@@ -68,9 +65,8 @@ static bool app_button_cb(void)
 
 /* STEP 18.1 - Define the thread function  */
 
-
 static struct my_lbs_cb app_callbacks = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -103,8 +99,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 };
 
 static int init_button(void)
@@ -151,8 +147,7 @@ void main(void)
 		return;
 	}
 	LOG_INF("Bluetooth initialized\n");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson4/blefund_less4_exer2/src/main.c
+++ b/lesson4/blefund_less4_exer2/src/main.c
@@ -15,9 +15,9 @@
 #include "my_lbs.h"
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                800, /*Min Advertising Interval 500ms (800*0.625ms) */
-                801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-                NULL); /* Set to NULL for undirected advertising*/
+		800, /*Min Advertising Interval 500ms (800*0.625ms) */
+		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise2, LOG_LEVEL_INF);
@@ -103,8 +103,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
 };
 
 static int init_button(void)
@@ -143,7 +143,7 @@ void main(void)
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-    bt_conn_cb_register(&connection_callbacks);
+	bt_conn_cb_register(&connection_callbacks);
 
 	err = my_lbs_init(&app_callbacks);
 	if (err) {

--- a/lesson4/blefund_less4_exer2/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2/src/my_lbs.c
@@ -26,11 +26,10 @@
 
 LOG_MODULE_DECLARE(Lesson4_Exercise2);
 
-
-static bool                   notify_mysensor_enabled;
-static bool                   indicate_enabled;
-static bool                   button_state;
-static struct my_lbs_cb       lbs_cb;
+static bool notify_mysensor_enabled;
+static bool indicate_enabled;
+static bool button_state;
+static struct my_lbs_cb lbs_cb;
 
 /* STEP 4 - Define an indication parameter */
 
@@ -39,19 +38,15 @@ static struct my_lbs_cb       lbs_cb;
 /* STEP 13 - Define the configuration change callback function for the MYSENSOR characteristic */
 
 // This function is called when a remote device has acknowledged the indication at its host layer
-static void indicate_cb(struct bt_conn *conn,
-			struct bt_gatt_indicate_params *params, uint8_t err)
+static void indicate_cb(struct bt_conn *conn, struct bt_gatt_indicate_params *params, uint8_t err)
 {
 	LOG_DBG("Indication %s\n", err != 0U ? "fail" : "success");
 }
 
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -79,52 +74,41 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	// get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		// Call the application callback function to update the get the current value of the button
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(my_lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-/* STEP 1 - Modify the Button characteristic declaration to support indication */
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ ,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-/* STEP 2 - Create and add the Client Characteristic Configuration Descriptor */
+BT_GATT_SERVICE_DEFINE(
+	my_lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+	/* STEP 1 - Modify the Button characteristic declaration to support indication */
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON, BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
+			       read_button, NULL, &button_state),
+	/* STEP 2 - Create and add the Client Characteristic Configuration Descriptor */
 
-
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_WRITE,
-			       NULL, write_led, NULL),
-/* STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE, BT_GATT_PERM_WRITE, NULL,
+			       write_led, NULL),
+	/* STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
 
 );
 /* A function to register application callbacks for the LED and Button characteristics  */
 int my_lbs_init(struct my_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 

--- a/lesson4/blefund_less4_exer2/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2/src/my_lbs.c
@@ -64,7 +64,7 @@ static ssize_t write_led(struct bt_conn *conn,
 	}
 
 	if (lbs_cb.led_cb) {
-		//Read the received value 
+		//Read the received value
 		uint8_t val = *((uint8_t *)buf);
 
 		if (val == 0x00 || val == 0x01) {

--- a/lesson4/blefund_less4_exer2/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2/src/my_lbs.c
@@ -80,10 +80,10 @@ static ssize_t write_led(struct bt_conn *conn,
 }
 
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	//get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;

--- a/lesson4/blefund_less4_exer2/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2/src/my_lbs.c
@@ -38,7 +38,7 @@ static struct my_lbs_cb       lbs_cb;
 
 /* STEP 13 - Define the configuration change callback function for the MYSENSOR characteristic */
 
-//This function is called when a remote device has acknowledged the indication at its host layer
+// This function is called when a remote device has acknowledged the indication at its host layer
 static void indicate_cb(struct bt_conn *conn,
 			struct bt_gatt_indicate_params *params, uint8_t err)
 {
@@ -64,11 +64,11 @@ static ssize_t write_led(struct bt_conn *conn,
 	}
 
 	if (lbs_cb.led_cb) {
-		//Read the received value
+		// Read the received value
 		uint8_t val = *((uint8_t *)buf);
 
 		if (val == 0x00 || val == 0x01) {
-			//Call the application callback function to update the LED state
+			// Call the application callback function to update the LED state
 			lbs_cb.led_cb(val ? true : false);
 		} else {
 			LOG_DBG("Write led: Incorrect value");
@@ -85,7 +85,7 @@ static ssize_t read_button(struct bt_conn *conn,
 			   uint16_t len,
 			   uint16_t offset)
 {
-	//get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
+	// get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;
 
 	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
@@ -117,7 +117,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 			       BT_GATT_CHRC_WRITE,
 			       BT_GATT_PERM_WRITE,
 			       NULL, write_led, NULL),
-/*STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
+/* STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
 
 );
 /* A function to register application callbacks for the LED and Button characteristics  */

--- a/lesson4/blefund_less4_exer2/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer2/src/my_lbs.h
@@ -20,26 +20,22 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /* STEP 11.1 - Assign a UUID to the MYSENSOR characteristic */
 
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
-
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /* STEP 11.2 - Convert the array to a generic UUID */
-
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -50,7 +46,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct my_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson4/blefund_less4_exer2/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer2/src/my_lbs.h
@@ -58,7 +58,7 @@ struct my_lbs_cb {
 /** @brief Initialize the LBS Service.
  *
  * This function registers application callback functions with the My LBS
- * Service 
+ * Service
  *
  * @param[in] callbacks Struct containing pointers to callback functions
  *			used by the service. This pointer can be NULL

--- a/lesson4/blefund_less4_exer2_solution/prj.conf
+++ b/lesson4/blefund_less4_exer2_solution/prj.conf
@@ -7,7 +7,7 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
@@ -15,6 +15,6 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="MY_LBS2"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson4/blefund_less4_exer2_solution/src/main.c
+++ b/lesson4/blefund_less4_exer2_solution/src/main.c
@@ -79,7 +79,7 @@ void send_data_thread(void)
 
 		k_sleep(K_MSEC(NOTIFY_INTERVAL));
 	}
-		
+
 }
 
 
@@ -92,7 +92,7 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	if (has_changed & USER_BUTTON) {
 		uint32_t user_button_state = button_state & USER_BUTTON;
-		/*STEP 6 - Send indication on a button press*/ 
+		/*STEP 6 - Send indication on a button press*/
 		my_lbs_send_button_state_indicate(user_button_state);
 		app_button_state = user_button_state ? true : false;
 	}
@@ -118,7 +118,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 
 struct bt_conn_cb connection_callbacks = {
     .connected              = on_connected,
-    .disconnected           = on_disconnected,  
+    .disconnected           = on_disconnected,
 };
 
 static int init_button(void)

--- a/lesson4/blefund_less4_exer2_solution/src/main.c
+++ b/lesson4/blefund_less4_exer2_solution/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -14,28 +13,29 @@
 #include <dk_buttons_and_leds.h>
 #include "my_lbs.h"
 
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /* Min Advertising Interval 500ms (800*0.625ms) */
-		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	800, /* Min Advertising Interval 500ms (800*0.625ms) */
+	801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson4_Exercise2, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define USER_LED                DK_LED3
-#define USER_BUTTON             DK_BTN1_MSK
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define USER_LED DK_LED3
+#define USER_BUTTON DK_BTN1_MSK
 
 #define STACKSIZE 1024
 #define PRIORITY 7
 
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_LED_BLINK_INTERVAL 1000
 /* STEP 17 - Define the interval at which you want to send data at */
-#define NOTIFY_INTERVAL         500
+#define NOTIFY_INTERVAL 500
 static bool app_button_state;
 /* STEP 15 - Define the data you want to stream over Bluetooth LE */
 static uint32_t app_sensor_value = 100;
@@ -71,7 +71,7 @@ static bool app_button_cb(void)
 /* STEP 18.1 - Define the thread function  */
 void send_data_thread(void)
 {
-	while(1){
+	while (1) {
 		/* Simulate data */
 		simulate_data();
 		/* Send notification, the function sends notifications only if a client is subscribed */
@@ -79,12 +79,10 @@ void send_data_thread(void)
 
 		k_sleep(K_MSEC(NOTIFY_INTERVAL));
 	}
-
 }
 
-
 static struct my_lbs_cb app_callbacks = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -117,8 +115,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 };
 
 static int init_button(void)
@@ -165,8 +163,7 @@ void main(void)
 		return;
 	}
 	LOG_INF("Bluetooth initialized\n");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;
@@ -179,5 +176,4 @@ void main(void)
 	}
 }
 /* STEP 18.2 - Define and initialize a thread to send data periodically */
-K_THREAD_DEFINE(send_data_thread_id, STACKSIZE, send_data_thread, NULL, NULL,
-		NULL, PRIORITY, 0, 0);
+K_THREAD_DEFINE(send_data_thread_id, STACKSIZE, send_data_thread, NULL, NULL, NULL, PRIORITY, 0, 0);

--- a/lesson4/blefund_less4_exer2_solution/src/main.c
+++ b/lesson4/blefund_less4_exer2_solution/src/main.c
@@ -15,9 +15,9 @@
 #include "my_lbs.h"
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		800, /*Min Advertising Interval 500ms (800*0.625ms) */
-		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-		NULL); /* Set to NULL for undirected advertising*/
+		800, /* Min Advertising Interval 500ms (800*0.625ms) */
+		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise2, LOG_LEVEL_INF);
@@ -92,7 +92,7 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	if (has_changed & USER_BUTTON) {
 		uint32_t user_button_state = button_state & USER_BUTTON;
-		/*STEP 6 - Send indication on a button press*/
+		/* STEP 6 - Send indication on a button press */
 		my_lbs_send_button_state_indicate(user_button_state);
 		app_button_state = user_button_state ? true : false;
 	}

--- a/lesson4/blefund_less4_exer2_solution/src/main.c
+++ b/lesson4/blefund_less4_exer2_solution/src/main.c
@@ -15,9 +15,9 @@
 #include "my_lbs.h"
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                800, /*Min Advertising Interval 500ms (800*0.625ms) */
-                801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-                NULL); /* Set to NULL for undirected advertising*/
+		800, /*Min Advertising Interval 500ms (800*0.625ms) */
+		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson4_Exercise2, LOG_LEVEL_INF);
@@ -117,8 +117,8 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
 };
 
 static int init_button(void)
@@ -157,7 +157,7 @@ void main(void)
 		LOG_ERR("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-    bt_conn_cb_register(&connection_callbacks);
+	bt_conn_cb_register(&connection_callbacks);
 
 	err = my_lbs_init(&app_callbacks);
 	if (err) {

--- a/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
@@ -75,7 +75,7 @@ static ssize_t write_led(struct bt_conn *conn,
 	}
 
 	if (lbs_cb.led_cb) {
-		//Read the received value 
+		//Read the received value
 		uint8_t val = *((uint8_t *)buf);
 
 		if (val == 0x00 || val == 0x01) {
@@ -137,7 +137,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 
 	BT_GATT_CCC(mylbsbc_ccc_mysensor_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
- 
+
 );
 /* A function to register application callbacks for the LED and Button characteristics  */
 int my_lbs_init(struct my_lbs_cb *callbacks)
@@ -171,7 +171,7 @@ int my_lbs_send_sensor_notify(uint32_t sensor_value)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &my_lbs_svc.attrs[7], 
+	return bt_gatt_notify(NULL, &my_lbs_svc.attrs[7],
 			      &sensor_value,
 			      sizeof(sensor_value));
 }

--- a/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
@@ -38,14 +38,14 @@ static struct bt_gatt_indicate_params ind_params;
 
 /* STEP 3 - Implement the configuration change callback function */
 static void mylbsbc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+				    uint16_t value)
 {
 	indicate_enabled = (value == BT_GATT_CCC_INDICATE);
 }
 
 /* STEP 13 - Define the configuration change callback function for the MYSENSOR characteristic */
 static void mylbsbc_ccc_mysensor_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+					     uint16_t value)
 {
 	notify_mysensor_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
@@ -91,10 +91,10 @@ static ssize_t write_led(struct bt_conn *conn,
 }
 
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	//get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;

--- a/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
@@ -50,7 +50,7 @@ static void mylbsbc_ccc_mysensor_cfg_changed(const struct bt_gatt_attr *attr,
 	notify_mysensor_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
-//This function is called when a remote device has acknowledged the indication at its host layer
+// This function is called when a remote device has acknowledged the indication at its host layer
 static void indicate_cb(struct bt_conn *conn,
 			struct bt_gatt_indicate_params *params, uint8_t err)
 {
@@ -75,11 +75,11 @@ static ssize_t write_led(struct bt_conn *conn,
 	}
 
 	if (lbs_cb.led_cb) {
-		//Read the received value
+		// Read the received value
 		uint8_t val = *((uint8_t *)buf);
 
 		if (val == 0x00 || val == 0x01) {
-			//Call the application callback function to update the LED state
+			// Call the application callback function to update the LED state
 			lbs_cb.led_cb(val ? true : false);
 		} else {
 			LOG_DBG("Write led: Incorrect value");
@@ -96,7 +96,7 @@ static ssize_t read_button(struct bt_conn *conn,
 			   uint16_t len,
 			   uint16_t offset)
 {
-	//get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
+	// get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;
 
 	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
@@ -129,7 +129,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 			       BT_GATT_CHRC_WRITE,
 			       BT_GATT_PERM_WRITE,
 			       NULL, write_led, NULL),
-/*STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
+/* STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
 	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_MYSENSOR,
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_NONE, NULL, NULL,
@@ -157,7 +157,7 @@ int my_lbs_send_button_state_indicate(bool button_state)
 		return -EACCES;
 	}
 	ind_params.attr = &my_lbs_svc.attrs[2];
-	ind_params.func = indicate_cb; //A remote device has ACKed at its host layer (ATT ACK)
+	ind_params.func = indicate_cb; // A remote device has ACKed at its host layer (ATT ACK)
 	ind_params.destroy = NULL;
 	ind_params.data = &button_state;
 	ind_params.len = sizeof(button_state);

--- a/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
+++ b/lesson4/blefund_less4_exer2_solution/src/my_lbs.c
@@ -26,43 +26,36 @@
 
 LOG_MODULE_DECLARE(Lesson4_Exercise2);
 
-
-static bool                   notify_enabled;
-static bool                   notify_mysensor_enabled;
-static bool                   indicate_enabled;
-static bool                   button_state;
-static struct my_lbs_cb       lbs_cb;
+static bool notify_enabled;
+static bool notify_mysensor_enabled;
+static bool indicate_enabled;
+static bool button_state;
+static struct my_lbs_cb lbs_cb;
 
 /* STEP 4 - Define an indication parameter */
 static struct bt_gatt_indicate_params ind_params;
 
 /* STEP 3 - Implement the configuration change callback function */
-static void mylbsbc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				    uint16_t value)
+static void mylbsbc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	indicate_enabled = (value == BT_GATT_CCC_INDICATE);
 }
 
 /* STEP 13 - Define the configuration change callback function for the MYSENSOR characteristic */
-static void mylbsbc_ccc_mysensor_cfg_changed(const struct bt_gatt_attr *attr,
-					     uint16_t value)
+static void mylbsbc_ccc_mysensor_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	notify_mysensor_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
 // This function is called when a remote device has acknowledged the indication at its host layer
-static void indicate_cb(struct bt_conn *conn,
-			struct bt_gatt_indicate_params *params, uint8_t err)
+static void indicate_cb(struct bt_conn *conn, struct bt_gatt_indicate_params *params, uint8_t err)
 {
 	LOG_DBG("Indication %s\n", err != 0U ? "fail" : "success");
 }
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -90,60 +83,46 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	// get a pointer to button_state which is passed in the BT_GATT_CHARACTERISTIC() and stored in attr->user_data
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		// Call the application callback function to update the get the current value of the button
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(my_lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-/* STEP 1 - Modify the Button characteristic declaration to support indication */
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_INDICATE,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-/* STEP 2 - Create and add the Client Characteristic Configuration Descriptor */
-	BT_GATT_CCC(mylbsbc_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+BT_GATT_SERVICE_DEFINE(
+	my_lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+	/* STEP 1 - Modify the Button characteristic declaration to support indication */
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON, BT_GATT_CHRC_READ | BT_GATT_CHRC_INDICATE,
+			       BT_GATT_PERM_READ, read_button, NULL, &button_state),
+	/* STEP 2 - Create and add the Client Characteristic Configuration Descriptor */
+	BT_GATT_CCC(mylbsbc_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_WRITE,
-			       NULL, write_led, NULL),
-/* STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_MYSENSOR,
-			       BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_NONE, NULL, NULL,
-			       NULL),
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE, BT_GATT_PERM_WRITE, NULL,
+			       write_led, NULL),
+	/* STEP 12 - Create and add the MYSENSOR characteristic and its CCCD  */
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_MYSENSOR, BT_GATT_CHRC_NOTIFY, BT_GATT_PERM_NONE, NULL,
+			       NULL, NULL),
 
-	BT_GATT_CCC(mylbsbc_ccc_mysensor_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+	BT_GATT_CCC(mylbsbc_ccc_mysensor_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 
 );
 /* A function to register application callbacks for the LED and Button characteristics  */
 int my_lbs_init(struct my_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
@@ -171,7 +150,5 @@ int my_lbs_send_sensor_notify(uint32_t sensor_value)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &my_lbs_svc.attrs[7],
-			      &sensor_value,
-			      sizeof(sensor_value));
+	return bt_gatt_notify(NULL, &my_lbs_svc.attrs[7], &sensor_value, sizeof(sensor_value));
 }

--- a/lesson4/blefund_less4_exer2_solution/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer2_solution/src/my_lbs.h
@@ -20,27 +20,25 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /* STEP 11.1 - Assign a UUID to the MYSENSOR characteristic */
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_MYSENSOR_VAL \
+#define BT_UUID_LBS_MYSENSOR_VAL                                                                   \
 	BT_UUID_128_ENCODE(0x00001526, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-#define BT_UUID_LBS                BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON         BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED            BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 /* STEP 11.2 - Convert the array to a generic UUID */
-#define BT_UUID_LBS_MYSENSOR       BT_UUID_DECLARE_128(BT_UUID_LBS_MYSENSOR_VAL)
+#define BT_UUID_LBS_MYSENSOR BT_UUID_DECLARE_128(BT_UUID_LBS_MYSENSOR_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -51,7 +49,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct my_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson4/blefund_less4_exer2_solution/src/my_lbs.h
+++ b/lesson4/blefund_less4_exer2_solution/src/my_lbs.h
@@ -59,7 +59,7 @@ struct my_lbs_cb {
 /** @brief Initialize the LBS Service.
  *
  * This function registers application callback functions with the My LBS
- * Service 
+ * Service
  *
  * @param[in] callbacks Struct containing pointers to callback functions
  *			used by the service. This pointer can be NULL

--- a/lesson4/blefund_less4_exer3/src/main.c
+++ b/lesson4/blefund_less4_exer3/src/main.c
@@ -306,7 +306,7 @@ static int uart_init(void)
 	} else {
 		return -ENOMEM;
 	}
-	// Send a welcome message over UART 
+	// Send a welcome message over UART
 	err = uart_tx(uart, tx->data, tx->len, SYS_FOREVER_MS);
 	if (err) {
 		LOG_ERR("Cannot display welcome message (err: %d)", err);

--- a/lesson4/blefund_less4_exer3/src/main.c
+++ b/lesson4/blefund_less4_exer3/src/main.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(Lesson4_Exercise3, LOG_LEVEL_INF);
 #define PRIORITY 7
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN	(sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
 #define RUN_STATUS_LED DK_LED1
 #define RUN_LED_BLINK_INTERVAL 1000
@@ -62,9 +62,7 @@ static struct k_work_delayable uart_work;
 
 /* STEP 6.2 - Declare the struct of the data item of the FIFOs */
 
-
 /* STEP 6.1 - Declare the FIFOs */
-
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -93,19 +91,16 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 	switch (evt->type) {
 	case UART_TX_DONE:
 		LOG_DBG("UART_TX_DONE");
-		if ((evt->data.tx.len == 0) ||
-			(!evt->data.tx.buf)) {
+		if ((evt->data.tx.len == 0) || (!evt->data.tx.buf)) {
 			return;
 		}
 
 		if (aborted_buf) {
-			buf = CONTAINER_OF(aborted_buf, struct uart_data_t,
-					   data);
+			buf = CONTAINER_OF(aborted_buf, struct uart_data_t, data);
 			aborted_buf = NULL;
 			aborted_len = 0;
 		} else {
-			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t,
-					   data);
+			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t, data);
 		}
 
 		k_free(buf);
@@ -131,7 +126,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		if ((evt->data.rx.buf[buf->len - 1] == '\n') ||
-			(evt->data.rx.buf[buf->len - 1] == '\r')) {
+		    (evt->data.rx.buf[buf->len - 1] == '\r')) {
 			disable_req = true;
 			uart_rx_disable(uart);
 		}
@@ -151,8 +146,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 			return;
 		}
 
-		uart_rx_enable(uart, buf->data, sizeof(buf->data),
-			       UART_WAIT_FOR_RX);
+		uart_rx_enable(uart, buf->data, sizeof(buf->data), UART_WAIT_FOR_RX);
 
 		break;
 
@@ -170,8 +164,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 
 	case UART_RX_BUF_RELEASED:
 		LOG_DBG("UART_RX_BUF_RELEASED");
-		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t,
-				   data);
+		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t, data);
 
 		if (buf->len > 0) {
 			/* STEP 9.1 -  Push the data received from the UART peripheral into the fifo_uart_rx_data FIFO */
@@ -189,11 +182,9 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		aborted_len += evt->data.tx.len;
-		buf = CONTAINER_OF(aborted_buf, struct uart_data_t,
-				   data);
+		buf = CONTAINER_OF(aborted_buf, struct uart_data_t, data);
 
-		uart_tx(uart, &buf->data[aborted_len],
-			buf->len - aborted_len, SYS_FOREVER_MS);
+		uart_tx(uart, &buf->data[aborted_len], buf->len - aborted_len, SYS_FOREVER_MS);
 
 		break;
 
@@ -220,8 +211,7 @@ static void uart_work_handler(struct k_work *item)
 
 static bool uart_test_async_api(const struct device *dev)
 {
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
 
 	return (api->callback_set != NULL);
 }
@@ -253,7 +243,6 @@ static int uart_init(void)
 	}
 
 	k_work_init_delayable(&uart_work, uart_work_handler);
-
 
 	if (IS_ENABLED(CONFIG_BT_NUS_UART_ASYNC_ADAPTER) && !uart_test_async_api(uart)) {
 		/* Implement API adapter */
@@ -354,8 +343,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
-static void security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -364,14 +352,13 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		LOG_INF("Security changed: %s level %u", addr, level);
 	} else {
-		LOG_WRN("Security failed: %s level %u err %d", addr,
-			level, err);
+		LOG_WRN("Security failed: %s level %u err %d", addr, level, err);
 	}
 }
 #endif
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected    = connected,
+	.connected = connected,
 	.disconnected = disconnected,
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
 	.security_changed = security_changed,
@@ -400,7 +387,6 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	LOG_INF("Press Button 1 to confirm, Button 2 to reject.");
 }
 
-
 static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -409,7 +395,6 @@ static void auth_cancel(struct bt_conn *conn)
 
 	LOG_INF("Pairing cancelled: %s", addr);
 }
-
 
 static void pairing_complete(struct bt_conn *conn, bool bonded)
 {
@@ -420,7 +405,6 @@ static void pairing_complete(struct bt_conn *conn, bool bonded)
 	LOG_INF("Pairing completed: %s, bonded: %d", addr, bonded);
 }
 
-
 static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -430,27 +414,24 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 	LOG_INF("Pairing failed conn: %s, reason %d", addr, reason);
 }
 
-
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.passkey_confirm = auth_passkey_confirm,
 	.cancel = auth_cancel,
 };
 
-static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
-	.pairing_complete = pairing_complete,
-	.pairing_failed = pairing_failed
-};
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = { .pairing_complete =
+									pairing_complete,
+								.pairing_failed = pairing_failed };
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
 static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
 #endif
 
-static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
-			  uint16_t len)
+static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
 {
 	int err;
-	char addr[BT_ADDR_LE_STR_LEN] = {0};
+	char addr[BT_ADDR_LE_STR_LEN] = { 0 };
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, ARRAY_SIZE(addr));
 
@@ -485,12 +466,9 @@ static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
 			tx->len++;
 		}
 		/* STEP 8.3 - Forward the data received over Bluetooth LE to the UART peripheral */
-
-
 	}
 }
 /* STEP 8.1 - Create a variable of type bt_nus_cb and initialize it */
-
 
 void error(void)
 {
@@ -558,7 +536,6 @@ void main(void)
 	configure_gpio();
 	/* STEP 7 - Initialize the UART Peripheral  */
 
-
 	if (IS_ENABLED(CONFIG_BT_NUS_SECURITY_ENABLED)) {
 		err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 		if (err) {
@@ -585,12 +562,9 @@ void main(void)
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
 	}
-/* STEP 8.2 - Pass your application callback function to the NUS service */
+	/* STEP 8.2 - Pass your application callback function to the NUS service */
 
-
-
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,
-			      ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;
@@ -602,6 +576,5 @@ void main(void)
 	}
 }
 /* STEP 9.3 - Define the thread function  */
-
 
 /* STEP 9.2 - Create a dedicated thread for sending the data over Bluetooth LE. */

--- a/lesson4/blefund_less4_exer3/src/main.c
+++ b/lesson4/blefund_less4_exer3/src/main.c
@@ -94,7 +94,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 	case UART_TX_DONE:
 		LOG_DBG("UART_TX_DONE");
 		if ((evt->data.tx.len == 0) ||
-		    (!evt->data.tx.buf)) {
+			(!evt->data.tx.buf)) {
 			return;
 		}
 
@@ -131,7 +131,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		if ((evt->data.rx.buf[buf->len - 1] == '\n') ||
-		    (evt->data.rx.buf[buf->len - 1] == '\r')) {
+			(evt->data.rx.buf[buf->len - 1] == '\r')) {
 			disable_req = true;
 			uart_rx_disable(uart);
 		}
@@ -484,7 +484,7 @@ static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
 			tx->data[tx->len] = '\n';
 			tx->len++;
 		}
-        /* STEP 8.3 - Forward the data received over Bluetooth LE to the UART peripheral */
+		/* STEP 8.3 - Forward the data received over Bluetooth LE to the UART peripheral */
 
 
 	}

--- a/lesson4/blefund_less4_exer3/src/main.c
+++ b/lesson4/blefund_less4_exer3/src/main.c
@@ -489,7 +489,7 @@ static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
 
 	}
 }
-/* STEP 8.1 - Create a variable of type bt_nus_cb and initialize it*/
+/* STEP 8.1 - Create a variable of type bt_nus_cb and initialize it */
 
 
 void error(void)
@@ -585,7 +585,7 @@ void main(void)
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
 	}
-/*STEP 8.2 - Pass your application callback function to the NUS service */
+/* STEP 8.2 - Pass your application callback function to the NUS service */
 
 
 

--- a/lesson4/blefund_less4_exer3/src/uart_async_adapter.c
+++ b/lesson4/blefund_less4_exer3/src/uart_async_adapter.c
@@ -14,7 +14,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_async_adapter);
 
-
 #if !IS_ENABLED(CONFIG_UART_ASYNC_API)
 #error "This adapter requires UART ASYNC API to be enabled"
 #endif
@@ -22,7 +21,6 @@ LOG_MODULE_REGISTER(uart_async_adapter);
 #if !IS_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN)
 #error "The adapter requires UART INTERRUPT API to be enabled"
 #endif
-
 
 /**
  * @brief Access the data inside device
@@ -66,18 +64,16 @@ static int callback_set(const struct device *dev, uart_callback_t callback, void
 
 static inline void notify_rx_buffer(const struct device *dev)
 {
-	struct uart_event event = {UART_RX_RDY};
+	struct uart_event event = { UART_RX_RDY };
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 	bool notify = false;
 
 	k_spinlock_key_t key = k_spin_lock(&(data->lock));
 
 	if (data->rx.buf) {
-
 		__ASSERT_NO_MSG(data->rx.curr_buf >= data->rx.buf);
 		__ASSERT_NO_MSG(data->rx.curr_buf >= data->rx.last_notify_buf);
 		if (data->rx.curr_buf > data->rx.last_notify_buf) {
-
 			event.data.rx.buf = data->rx.buf;
 			event.data.rx.len = data->rx.curr_buf - data->rx.last_notify_buf;
 			event.data.rx.offset = data->rx.last_notify_buf - data->rx.buf;
@@ -97,10 +93,7 @@ static inline void notify_rx_buffer(const struct device *dev)
 
 static inline void notify_rx_buffer_release(const struct device *dev, uint8_t *buf)
 {
-	struct uart_event event = {
-		.type = UART_RX_BUF_RELEASED,
-		.data.rx_buf.buf = buf
-	};
+	struct uart_event event = { .type = UART_RX_BUF_RELEASED, .data.rx_buf.buf = buf };
 	LOG_DBG("Notification: UART_RX_BUF_RELEASED");
 	user_callback(dev, &event);
 }
@@ -177,7 +170,7 @@ static int tx(const struct device *dev, const uint8_t *buf, size_t len, int32_t 
 static int tx_abort(const struct device *dev)
 {
 	int ret = 0;
-	struct uart_event event = {UART_TX_ABORTED};
+	struct uart_event event = { UART_TX_ABORTED };
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 
 	data->tx.enabled = false;
@@ -205,7 +198,6 @@ static int tx_abort(const struct device *dev)
 	}
 	return ret;
 }
-
 
 static int rx_enable(const struct device *dev, uint8_t *buf, size_t len, int32_t timeout)
 {
@@ -256,7 +248,7 @@ static int rx_disable(const struct device *dev)
 {
 	int ret = 0;
 	struct uart_async_adapter_data *data = access_dev_data(dev);
-	struct uart_event event_disabled = {UART_RX_DISABLED};
+	struct uart_event event_disabled = { UART_RX_DISABLED };
 
 	data->rx.enabled = false;
 	uart_irq_rx_disable(data->target);
@@ -332,7 +324,6 @@ static int config_get(const struct device *dev, struct uart_config *cfg)
 	return uart_config_get(data->target, cfg);
 }
 
-
 #ifdef CONFIG_UART_LINE_CTRL
 
 static int line_ctrl_set(const struct device *dev, uint32_t ctrl, uint32_t val)
@@ -405,7 +396,7 @@ static inline void on_tx_complete(const struct device *dev, struct uart_async_ad
 {
 	LOG_DBG("%s: Enter(%s)", __func__, dev->name);
 	if (!data->tx.size_left) {
-		struct uart_event event = {UART_TX_DONE};
+		struct uart_event event = { UART_TX_DONE };
 
 		data->tx.enabled = false;
 		uart_irq_tx_disable(data->target);
@@ -497,14 +488,10 @@ static inline void on_rx_ready(const struct device *dev, struct uart_async_adapt
 	LOG_DBG("%s: Exit", __func__);
 }
 
-static inline void on_error(const struct device *dev,
-			    struct uart_async_adapter_data *data,
+static inline void on_error(const struct device *dev, struct uart_async_adapter_data *data,
 			    int rx_err)
 {
-	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = rx_err
-	};
+	struct uart_event event = { .type = UART_RX_STOPPED, .data.rx_stop.reason = rx_err };
 
 	LOG_DBG("%s: Enter(%s)", __func__, dev->name);
 	rx_disable(data->target);
@@ -518,7 +505,7 @@ static void uart_irq_handler(const struct device *target_dev, void *context)
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 
 	__ASSERT(target_dev == data->target,
-		"IRQ handler called with a context that seems uninitialized.");
+		 "IRQ handler called with a context that seems uninitialized.");
 	LOG_DBG("irq_handler: Enter");
 	if (uart_irq_update(target_dev) && uart_irq_is_pending(target_dev)) {
 		if (data->tx.enabled && uart_irq_tx_ready(target_dev)) {
@@ -566,10 +553,9 @@ const struct uart_driver_api uart_async_adapter_driver_api = {
 #endif
 
 #ifdef CONFIG_UART_DRV_CMD
-	.drv_cmd = drv_cmd
+				 .drv_cmd = drv_cmd
 #endif
 };
-
 
 static void tx_timeout(struct k_timer *timer)
 {
@@ -590,7 +576,7 @@ void uart_async_adapter_init(const struct device *dev, const struct device *targ
 	__ASSERT_NO_MSG(dev);
 	__ASSERT_NO_MSG(dev->api);
 	__ASSERT(dev->api == &uart_async_adapter_driver_api,
-		"This is not uart_async_adapter device");
+		 "This is not uart_async_adapter device");
 
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 

--- a/lesson4/blefund_less4_exer3/src/uart_async_adapter.h
+++ b/lesson4/blefund_less4_exer3/src/uart_async_adapter.h
@@ -23,7 +23,6 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
 
-
 /**
  * @brief UART asynch adapter data structure
  *
@@ -101,15 +100,15 @@ extern const struct uart_driver_api uart_async_adapter_driver_api;
  *
  * @name _dev The name of the created device instance
  */
-#define UART_ASYNC_ADAPTER_INST_DEFINE(_dev) \
-	static struct uart_async_adapter_data UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev); \
-	static struct device_state UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev); \
-	static const struct device UART_ASYNC_ADAPTER_INST_NAME(_dev) = { \
-		.name = STRINGIFY(_dev), \
-		.api = &uart_async_adapter_driver_api, \
-		.state = &UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev), \
-		.data = &UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev), \
-	}; \
+#define UART_ASYNC_ADAPTER_INST_DEFINE(_dev)                                                       \
+	static struct uart_async_adapter_data UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev);             \
+	static struct device_state UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev);                       \
+	static const struct device UART_ASYNC_ADAPTER_INST_NAME(_dev) = {                          \
+		.name = STRINGIFY(_dev),                                                           \
+		.api = &uart_async_adapter_driver_api,                                             \
+		.state = &UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev),                                \
+		.data = &UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev),                                  \
+	};                                                                                         \
 	static const struct device *const _dev = &UART_ASYNC_ADAPTER_INST_NAME(_dev)
 
 /**

--- a/lesson4/blefund_less4_exer3_solution/src/main.c
+++ b/lesson4/blefund_less4_exer3_solution/src/main.c
@@ -68,7 +68,7 @@ struct uart_data_t {
 };
 
 /* STEP 6.1 - Declare the FIFOs */
-static K_FIFO_DEFINE(fifo_uart_tx_data); 
+static K_FIFO_DEFINE(fifo_uart_tx_data);
 static K_FIFO_DEFINE(fifo_uart_rx_data);
 
 static const struct bt_data ad[] = {
@@ -311,7 +311,7 @@ static int uart_init(void)
 	} else {
 		return -ENOMEM;
 	}
-	// Send a welcome message over UART 
+	// Send a welcome message over UART
 	err = uart_tx(uart, tx->data, tx->len, SYS_FOREVER_MS);
 	if (err) {
 		LOG_ERR("Cannot display welcome message (err: %d)", err);

--- a/lesson4/blefund_less4_exer3_solution/src/main.c
+++ b/lesson4/blefund_less4_exer3_solution/src/main.c
@@ -496,7 +496,7 @@ static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
 		}
 	}
 }
-/* STEP 8.1 - Create a variable of type bt_nus_cb and initialize it*/
+/* STEP 8.1 - Create a variable of type bt_nus_cb and initialize it */
 static struct bt_nus_cb nus_cb = {
 	.received = bt_receive_cb,
 };

--- a/lesson4/blefund_less4_exer3_solution/src/main.c
+++ b/lesson4/blefund_less4_exer3_solution/src/main.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(Lesson4_Exercise3, LOG_LEVEL_INF);
 #define PRIORITY 7
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN	(sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
 #define RUN_STATUS_LED DK_LED1
 #define RUN_LED_BLINK_INTERVAL 1000
@@ -98,19 +98,16 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 	switch (evt->type) {
 	case UART_TX_DONE:
 		LOG_DBG("UART_TX_DONE");
-		if ((evt->data.tx.len == 0) ||
-			(!evt->data.tx.buf)) {
+		if ((evt->data.tx.len == 0) || (!evt->data.tx.buf)) {
 			return;
 		}
 
 		if (aborted_buf) {
-			buf = CONTAINER_OF(aborted_buf, struct uart_data_t,
-					   data);
+			buf = CONTAINER_OF(aborted_buf, struct uart_data_t, data);
 			aborted_buf = NULL;
 			aborted_len = 0;
 		} else {
-			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t,
-					   data);
+			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t, data);
 		}
 
 		k_free(buf);
@@ -136,7 +133,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		if ((evt->data.rx.buf[buf->len - 1] == '\n') ||
-			(evt->data.rx.buf[buf->len - 1] == '\r')) {
+		    (evt->data.rx.buf[buf->len - 1] == '\r')) {
 			disable_req = true;
 			uart_rx_disable(uart);
 		}
@@ -156,8 +153,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 			return;
 		}
 
-		uart_rx_enable(uart, buf->data, sizeof(buf->data),
-			       UART_WAIT_FOR_RX);
+		uart_rx_enable(uart, buf->data, sizeof(buf->data), UART_WAIT_FOR_RX);
 
 		break;
 
@@ -175,8 +171,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 
 	case UART_RX_BUF_RELEASED:
 		LOG_DBG("UART_RX_BUF_RELEASED");
-		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t,
-				   data);
+		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t, data);
 
 		if (buf->len > 0) {
 			/* STEP 9.1 -  Push the data received from the UART peripheral into the fifo_uart_rx_data FIFO */
@@ -194,11 +189,9 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		aborted_len += evt->data.tx.len;
-		buf = CONTAINER_OF(aborted_buf, struct uart_data_t,
-				   data);
+		buf = CONTAINER_OF(aborted_buf, struct uart_data_t, data);
 
-		uart_tx(uart, &buf->data[aborted_len],
-			buf->len - aborted_len, SYS_FOREVER_MS);
+		uart_tx(uart, &buf->data[aborted_len], buf->len - aborted_len, SYS_FOREVER_MS);
 
 		break;
 
@@ -225,8 +218,7 @@ static void uart_work_handler(struct k_work *item)
 
 static bool uart_test_async_api(const struct device *dev)
 {
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
 
 	return (api->callback_set != NULL);
 }
@@ -258,7 +250,6 @@ static int uart_init(void)
 	}
 
 	k_work_init_delayable(&uart_work, uart_work_handler);
-
 
 	if (IS_ENABLED(CONFIG_BT_NUS_UART_ASYNC_ADAPTER) && !uart_test_async_api(uart)) {
 		/* Implement API adapter */
@@ -359,8 +350,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
-static void security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -369,14 +359,13 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		LOG_INF("Security changed: %s level %u", addr, level);
 	} else {
-		LOG_WRN("Security failed: %s level %u err %d", addr,
-			level, err);
+		LOG_WRN("Security failed: %s level %u err %d", addr, level, err);
 	}
 }
 #endif
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected    = connected,
+	.connected = connected,
 	.disconnected = disconnected,
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
 	.security_changed = security_changed,
@@ -405,7 +394,6 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	LOG_INF("Press Button 1 to confirm, Button 2 to reject.");
 }
 
-
 static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -414,7 +402,6 @@ static void auth_cancel(struct bt_conn *conn)
 
 	LOG_INF("Pairing cancelled: %s", addr);
 }
-
 
 static void pairing_complete(struct bt_conn *conn, bool bonded)
 {
@@ -425,7 +412,6 @@ static void pairing_complete(struct bt_conn *conn, bool bonded)
 	LOG_INF("Pairing completed: %s, bonded: %d", addr, bonded);
 }
 
-
 static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -435,27 +421,24 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 	LOG_INF("Pairing failed conn: %s, reason %d", addr, reason);
 }
 
-
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.passkey_confirm = auth_passkey_confirm,
 	.cancel = auth_cancel,
 };
 
-static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
-	.pairing_complete = pairing_complete,
-	.pairing_failed = pairing_failed
-};
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = { .pairing_complete =
+									pairing_complete,
+								.pairing_failed = pairing_failed };
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
 static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
 #endif
 
-static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
-			  uint16_t len)
+static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
 {
 	int err;
-	char addr[BT_ADDR_LE_STR_LEN] = {0};
+	char addr[BT_ADDR_LE_STR_LEN] = { 0 };
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, ARRAY_SIZE(addr));
 
@@ -597,15 +580,14 @@ void main(void)
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
 	}
-/* STEP 8.2 - Pass your application callback function to the NUS service */
+	/* STEP 8.2 - Pass your application callback function to the NUS service */
 	err = bt_nus_init(&nus_cb);
 	if (err) {
 		LOG_ERR("Failed to initialize UART service (err: %d)", err);
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,
-			      ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;
@@ -624,8 +606,7 @@ void ble_write_thread(void)
 
 	for (;;) {
 		/* Wait indefinitely for data from the UART peripheral */
-		struct uart_data_t *buf = k_fifo_get(&fifo_uart_rx_data,
-						     K_FOREVER);
+		struct uart_data_t *buf = k_fifo_get(&fifo_uart_rx_data, K_FOREVER);
 		/* Send data over Bluetooth LE to remote device(s) */
 		if (bt_nus_send(NULL, buf->data, buf->len)) {
 			LOG_WRN("Failed to send data over BLE connection");
@@ -635,5 +616,4 @@ void ble_write_thread(void)
 	}
 }
 /* STEP 9.2 - Create a dedicated thread for sending the data over Bluetooth LE. */
-K_THREAD_DEFINE(ble_write_thread_id, STACKSIZE, ble_write_thread, NULL, NULL,
-		NULL, PRIORITY, 0, 0);
+K_THREAD_DEFINE(ble_write_thread_id, STACKSIZE, ble_write_thread, NULL, NULL, NULL, PRIORITY, 0, 0);

--- a/lesson4/blefund_less4_exer3_solution/src/main.c
+++ b/lesson4/blefund_less4_exer3_solution/src/main.c
@@ -99,7 +99,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 	case UART_TX_DONE:
 		LOG_DBG("UART_TX_DONE");
 		if ((evt->data.tx.len == 0) ||
-		    (!evt->data.tx.buf)) {
+			(!evt->data.tx.buf)) {
 			return;
 		}
 
@@ -136,7 +136,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		if ((evt->data.rx.buf[buf->len - 1] == '\n') ||
-		    (evt->data.rx.buf[buf->len - 1] == '\r')) {
+			(evt->data.rx.buf[buf->len - 1] == '\r')) {
 			disable_req = true;
 			uart_rx_disable(uart);
 		}
@@ -489,7 +489,7 @@ static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
 			tx->data[tx->len] = '\n';
 			tx->len++;
 		}
-        /* STEP 8.3 - Forward the data received over Bluetooth LE to the UART peripheral */
+		/* STEP 8.3 - Forward the data received over Bluetooth LE to the UART peripheral */
 		err = uart_tx(uart, tx->data, tx->len, SYS_FOREVER_MS);
 		if (err) {
 			k_fifo_put(&fifo_uart_tx_data, tx);
@@ -626,7 +626,7 @@ void ble_write_thread(void)
 		/* Wait indefinitely for data from the UART peripheral */
 		struct uart_data_t *buf = k_fifo_get(&fifo_uart_rx_data,
 						     K_FOREVER);
-        /* Send data over Bluetooth LE to remote device(s) */
+		/* Send data over Bluetooth LE to remote device(s) */
 		if (bt_nus_send(NULL, buf->data, buf->len)) {
 			LOG_WRN("Failed to send data over BLE connection");
 		}

--- a/lesson4/blefund_less4_exer3_solution/src/uart_async_adapter.c
+++ b/lesson4/blefund_less4_exer3_solution/src/uart_async_adapter.c
@@ -14,7 +14,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_async_adapter);
 
-
 #if !IS_ENABLED(CONFIG_UART_ASYNC_API)
 #error "This adapter requires UART ASYNC API to be enabled"
 #endif
@@ -22,7 +21,6 @@ LOG_MODULE_REGISTER(uart_async_adapter);
 #if !IS_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN)
 #error "The adapter requires UART INTERRUPT API to be enabled"
 #endif
-
 
 /**
  * @brief Access the data inside device
@@ -66,18 +64,16 @@ static int callback_set(const struct device *dev, uart_callback_t callback, void
 
 static inline void notify_rx_buffer(const struct device *dev)
 {
-	struct uart_event event = {UART_RX_RDY};
+	struct uart_event event = { UART_RX_RDY };
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 	bool notify = false;
 
 	k_spinlock_key_t key = k_spin_lock(&(data->lock));
 
 	if (data->rx.buf) {
-
 		__ASSERT_NO_MSG(data->rx.curr_buf >= data->rx.buf);
 		__ASSERT_NO_MSG(data->rx.curr_buf >= data->rx.last_notify_buf);
 		if (data->rx.curr_buf > data->rx.last_notify_buf) {
-
 			event.data.rx.buf = data->rx.buf;
 			event.data.rx.len = data->rx.curr_buf - data->rx.last_notify_buf;
 			event.data.rx.offset = data->rx.last_notify_buf - data->rx.buf;
@@ -97,10 +93,7 @@ static inline void notify_rx_buffer(const struct device *dev)
 
 static inline void notify_rx_buffer_release(const struct device *dev, uint8_t *buf)
 {
-	struct uart_event event = {
-		.type = UART_RX_BUF_RELEASED,
-		.data.rx_buf.buf = buf
-	};
+	struct uart_event event = { .type = UART_RX_BUF_RELEASED, .data.rx_buf.buf = buf };
 	LOG_DBG("Notification: UART_RX_BUF_RELEASED");
 	user_callback(dev, &event);
 }
@@ -177,7 +170,7 @@ static int tx(const struct device *dev, const uint8_t *buf, size_t len, int32_t 
 static int tx_abort(const struct device *dev)
 {
 	int ret = 0;
-	struct uart_event event = {UART_TX_ABORTED};
+	struct uart_event event = { UART_TX_ABORTED };
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 
 	data->tx.enabled = false;
@@ -205,7 +198,6 @@ static int tx_abort(const struct device *dev)
 	}
 	return ret;
 }
-
 
 static int rx_enable(const struct device *dev, uint8_t *buf, size_t len, int32_t timeout)
 {
@@ -256,7 +248,7 @@ static int rx_disable(const struct device *dev)
 {
 	int ret = 0;
 	struct uart_async_adapter_data *data = access_dev_data(dev);
-	struct uart_event event_disabled = {UART_RX_DISABLED};
+	struct uart_event event_disabled = { UART_RX_DISABLED };
 
 	data->rx.enabled = false;
 	uart_irq_rx_disable(data->target);
@@ -332,7 +324,6 @@ static int config_get(const struct device *dev, struct uart_config *cfg)
 	return uart_config_get(data->target, cfg);
 }
 
-
 #ifdef CONFIG_UART_LINE_CTRL
 
 static int line_ctrl_set(const struct device *dev, uint32_t ctrl, uint32_t val)
@@ -405,7 +396,7 @@ static inline void on_tx_complete(const struct device *dev, struct uart_async_ad
 {
 	LOG_DBG("%s: Enter(%s)", __func__, dev->name);
 	if (!data->tx.size_left) {
-		struct uart_event event = {UART_TX_DONE};
+		struct uart_event event = { UART_TX_DONE };
 
 		data->tx.enabled = false;
 		uart_irq_tx_disable(data->target);
@@ -497,14 +488,10 @@ static inline void on_rx_ready(const struct device *dev, struct uart_async_adapt
 	LOG_DBG("%s: Exit", __func__);
 }
 
-static inline void on_error(const struct device *dev,
-			    struct uart_async_adapter_data *data,
+static inline void on_error(const struct device *dev, struct uart_async_adapter_data *data,
 			    int rx_err)
 {
-	struct uart_event event = {
-		.type = UART_RX_STOPPED,
-		.data.rx_stop.reason = rx_err
-	};
+	struct uart_event event = { .type = UART_RX_STOPPED, .data.rx_stop.reason = rx_err };
 
 	LOG_DBG("%s: Enter(%s)", __func__, dev->name);
 	rx_disable(data->target);
@@ -518,7 +505,7 @@ static void uart_irq_handler(const struct device *target_dev, void *context)
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 
 	__ASSERT(target_dev == data->target,
-		"IRQ handler called with a context that seems uninitialized.");
+		 "IRQ handler called with a context that seems uninitialized.");
 	LOG_DBG("irq_handler: Enter");
 	if (uart_irq_update(target_dev) && uart_irq_is_pending(target_dev)) {
 		if (data->tx.enabled && uart_irq_tx_ready(target_dev)) {
@@ -566,10 +553,9 @@ const struct uart_driver_api uart_async_adapter_driver_api = {
 #endif
 
 #ifdef CONFIG_UART_DRV_CMD
-	.drv_cmd = drv_cmd
+				 .drv_cmd = drv_cmd
 #endif
 };
-
 
 static void tx_timeout(struct k_timer *timer)
 {
@@ -590,7 +576,7 @@ void uart_async_adapter_init(const struct device *dev, const struct device *targ
 	__ASSERT_NO_MSG(dev);
 	__ASSERT_NO_MSG(dev->api);
 	__ASSERT(dev->api == &uart_async_adapter_driver_api,
-		"This is not uart_async_adapter device");
+		 "This is not uart_async_adapter device");
 
 	struct uart_async_adapter_data *data = access_dev_data(dev);
 

--- a/lesson4/blefund_less4_exer3_solution/src/uart_async_adapter.h
+++ b/lesson4/blefund_less4_exer3_solution/src/uart_async_adapter.h
@@ -23,7 +23,6 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
 
-
 /**
  * @brief UART asynch adapter data structure
  *
@@ -101,15 +100,15 @@ extern const struct uart_driver_api uart_async_adapter_driver_api;
  *
  * @name _dev The name of the created device instance
  */
-#define UART_ASYNC_ADAPTER_INST_DEFINE(_dev) \
-	static struct uart_async_adapter_data UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev); \
-	static struct device_state UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev); \
-	static const struct device UART_ASYNC_ADAPTER_INST_NAME(_dev) = { \
-		.name = STRINGIFY(_dev), \
-		.api = &uart_async_adapter_driver_api, \
-		.state = &UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev), \
-		.data = &UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev), \
-	}; \
+#define UART_ASYNC_ADAPTER_INST_DEFINE(_dev)                                                       \
+	static struct uart_async_adapter_data UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev);             \
+	static struct device_state UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev);                       \
+	static const struct device UART_ASYNC_ADAPTER_INST_NAME(_dev) = {                          \
+		.name = STRINGIFY(_dev),                                                           \
+		.api = &uart_async_adapter_driver_api,                                             \
+		.state = &UART_ASYNC_ADAPTER_INST_STATE_NAME(_dev),                                \
+		.data = &UART_ASYNC_ADAPTER_INST_DATA_NAME(_dev),                                  \
+	};                                                                                         \
 	static const struct device *const _dev = &UART_ASYNC_ADAPTER_INST_NAME(_dev)
 
 /**

--- a/lesson5/blefund_less5_exer1/prj.conf
+++ b/lesson5/blefund_less5_exer1/prj.conf
@@ -18,6 +18,6 @@ CONFIG_DK_LIBRARY=y
 
 # STEP 4 - Add the Security Management Protocol layer to the Bluetooth LE stack
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson5/blefund_less5_exer1/src/lbs.c
+++ b/lesson5/blefund_less5_exer1/src/lbs.c
@@ -28,23 +28,19 @@
 #define CONFIG_BT_LBS_LOG_LEVEL 3
 LOG_MODULE_REGISTER(bt_lbs, CONFIG_BT_LBS_LOG_LEVEL);
 
-static bool                   notify_enabled;
-static bool                   button_state;
-static struct bt_lbs_cb       lbs_cb;
+static bool notify_enabled;
+static bool button_state;
+static struct bt_lbs_cb lbs_cb;
 
-static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	notify_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -69,48 +65,36 @@ static ssize_t write_led(struct bt_conn *conn,
 
 	return len;
 }
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-	BT_GATT_CCC(lbslc_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
-/* STEP 1.1 - Change the LED characteristic permission to require encryption */
-/* STEP 8 - Change the LED characteristic permission to require pairing with authentication */
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_WRITE,
-			       NULL, write_led, NULL),
-);
+BT_GATT_SERVICE_DEFINE(
+	lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON, BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+			       BT_GATT_PERM_READ, read_button, NULL, &button_state),
+	BT_GATT_CCC(lbslc_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+	/* STEP 1.1 - Change the LED characteristic permission to require encryption */
+	/* STEP 8 - Change the LED characteristic permission to require pairing with authentication */
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE, BT_GATT_PERM_WRITE, NULL,
+			       write_led, NULL), );
 
 int bt_lbs_init(struct bt_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
@@ -123,7 +107,5 @@ int bt_lbs_send_button_state(bool button_state)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &lbs_svc.attrs[2],
-			      &button_state,
-			      sizeof(button_state));
+	return bt_gatt_notify(NULL, &lbs_svc.attrs[2], &button_state, sizeof(button_state));
 }

--- a/lesson5/blefund_less5_exer1/src/lbs.c
+++ b/lesson5/blefund_less5_exer1/src/lbs.c
@@ -70,10 +70,10 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	const char *value = attr->user_data;
 

--- a/lesson5/blefund_less5_exer1/src/lbs.h
+++ b/lesson5/blefund_less5_exer1/src/lbs.h
@@ -20,21 +20,18 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -45,7 +42,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct bt_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson5/blefund_less5_exer1/src/main.c
+++ b/lesson5/blefund_less5_exer1/src/main.c
@@ -128,7 +128,7 @@ void main(void)
 		LOG_INF("Button init failed (err %d)\n", err);
 		return;
 	}
-	
+
 	/* STEP 10 - Register the authentication callbacks */
 
 

--- a/lesson5/blefund_less5_exer1/src/main.c
+++ b/lesson5/blefund_less5_exer1/src/main.c
@@ -16,16 +16,15 @@
 
 LOG_MODULE_REGISTER(Lesson5_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define USER_LED DK_LED3
+#define USER_BUTTON DK_BTN1_MSK
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define USER_LED                DK_LED3
-#define USER_BUTTON             DK_BTN1_MSK
-
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static bool app_button_state;
 
@@ -60,9 +59,9 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 /* STEP 5.2 Define the callback function on_security_changed() */
 
 struct bt_conn_cb connection_callbacks = {
-	.connected        = on_connected,
-	.disconnected     = on_disconnected,
-/* STEP 5.1 - Add the security_changed member to the callback structure */
+	.connected = on_connected,
+	.disconnected = on_disconnected,
+	/* STEP 5.1 - Add the security_changed member to the callback structure */
 
 };
 
@@ -71,7 +70,6 @@ struct bt_conn_cb connection_callbacks = {
 /* STEP 9.2 - Define the callback function auth_cancel */
 
 /* STEP 9.3 - Declare the authenticated pairing callback structure */
-
 
 static void app_led_cb(bool led_state)
 {
@@ -84,7 +82,7 @@ static bool app_button_cb(void)
 }
 
 static struct bt_lbs_cb lbs_callbacs = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -131,7 +129,6 @@ void main(void)
 
 	/* STEP 10 - Register the authentication callbacks */
 
-
 	bt_conn_cb_register(&connection_callbacks);
 
 	err = bt_enable(NULL);
@@ -148,8 +145,7 @@ void main(void)
 
 	LOG_INF("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_INF("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson5/blefund_less5_exer1_solution/prj.conf
+++ b/lesson5/blefund_less5_exer1_solution/prj.conf
@@ -19,6 +19,6 @@ CONFIG_DK_LIBRARY=y
 # STEP 4 - Add the Security Management Protocol layer to the Bluetooth LE stack
 CONFIG_BT_SMP=y
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson5/blefund_less5_exer1_solution/src/lbs.c
+++ b/lesson5/blefund_less5_exer1_solution/src/lbs.c
@@ -100,7 +100,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 	BT_GATT_CCC(lbslc_ccc_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 /* STEP 1.1 - Change the LED characteristic permission to require encryption */
-/* STEP 8 - Change the LED characteristic permission to require pairing with authentication */			
+/* STEP 8 - Change the LED characteristic permission to require pairing with authentication */
 	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
 			       BT_GATT_CHRC_WRITE,
 			//	   BT_GATT_PERM_WRITE_ENCRYPT,

--- a/lesson5/blefund_less5_exer1_solution/src/lbs.c
+++ b/lesson5/blefund_less5_exer1_solution/src/lbs.c
@@ -28,23 +28,19 @@
 #define CONFIG_BT_LBS_LOG_LEVEL 3
 LOG_MODULE_REGISTER(bt_lbs, CONFIG_BT_LBS_LOG_LEVEL);
 
-static bool                   notify_enabled;
-static bool                   button_state;
-static struct bt_lbs_cb       lbs_cb;
+static bool notify_enabled;
+static bool button_state;
+static struct bt_lbs_cb lbs_cb;
 
-static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	notify_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -69,49 +65,37 @@ static ssize_t write_led(struct bt_conn *conn,
 
 	return len;
 }
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-	BT_GATT_CCC(lbslc_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
-/* STEP 1.1 - Change the LED characteristic permission to require encryption */
-/* STEP 8 - Change the LED characteristic permission to require pairing with authentication */
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
+BT_GATT_SERVICE_DEFINE(
+	lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON, BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+			       BT_GATT_PERM_READ, read_button, NULL, &button_state),
+	BT_GATT_CCC(lbslc_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+	/* STEP 1.1 - Change the LED characteristic permission to require encryption */
+	/* STEP 8 - Change the LED characteristic permission to require pairing with authentication */
+	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE,
 			       // BT_GATT_PERM_WRITE_ENCRYPT,
-			       BT_GATT_PERM_WRITE_AUTHEN,
-			       NULL, write_led, NULL),
-);
+			       BT_GATT_PERM_WRITE_AUTHEN, NULL, write_led, NULL), );
 
 int bt_lbs_init(struct bt_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
@@ -124,7 +108,5 @@ int bt_lbs_send_button_state(bool button_state)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &lbs_svc.attrs[2],
-			      &button_state,
-			      sizeof(button_state));
+	return bt_gatt_notify(NULL, &lbs_svc.attrs[2], &button_state, sizeof(button_state));
 }

--- a/lesson5/blefund_less5_exer1_solution/src/lbs.c
+++ b/lesson5/blefund_less5_exer1_solution/src/lbs.c
@@ -70,10 +70,10 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	const char *value = attr->user_data;
 
@@ -103,7 +103,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 /* STEP 8 - Change the LED characteristic permission to require pairing with authentication */
 	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
 			       BT_GATT_CHRC_WRITE,
-			//	   BT_GATT_PERM_WRITE_ENCRYPT,
+			       // BT_GATT_PERM_WRITE_ENCRYPT,
 			       BT_GATT_PERM_WRITE_AUTHEN,
 			       NULL, write_led, NULL),
 );

--- a/lesson5/blefund_less5_exer1_solution/src/lbs.h
+++ b/lesson5/blefund_less5_exer1_solution/src/lbs.h
@@ -20,21 +20,18 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -45,7 +42,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct bt_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson5/blefund_less5_exer1_solution/src/main.c
+++ b/lesson5/blefund_less5_exer1_solution/src/main.c
@@ -170,7 +170,7 @@ void main(void)
 	}
 
 	bt_conn_cb_register(&connection_callbacks);
-	
+
 	err = bt_enable(NULL);
 	if (err) {
 		LOG_INF("Bluetooth init failed (err %d)\n", err);

--- a/lesson5/blefund_less5_exer1_solution/src/main.c
+++ b/lesson5/blefund_less5_exer1_solution/src/main.c
@@ -59,7 +59,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 
 /* STEP 5.2 Define the callback function security_changed() */
 static void on_security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+				enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 

--- a/lesson5/blefund_less5_exer1_solution/src/main.c
+++ b/lesson5/blefund_less5_exer1_solution/src/main.c
@@ -16,16 +16,15 @@
 
 LOG_MODULE_REGISTER(Lesson5_Exercise1, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define USER_LED DK_LED3
+#define USER_BUTTON DK_BTN1_MSK
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define USER_LED                DK_LED3
-#define USER_BUTTON             DK_BTN1_MSK
-
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static bool app_button_state;
 
@@ -58,8 +57,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 /* STEP 5.2 Define the callback function security_changed() */
-static void on_security_changed(struct bt_conn *conn, bt_security_t level,
-				enum bt_security_err err)
+static void on_security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -68,14 +66,13 @@ static void on_security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		LOG_INF("Security changed: %s level %u\n", addr, level);
 	} else {
-		LOG_INF("Security failed: %s level %u err %d\n", addr, level,
-			err);
+		LOG_INF("Security failed: %s level %u err %d\n", addr, level, err);
 	}
 }
 struct bt_conn_cb connection_callbacks = {
-	.connected        = on_connected,
-	.disconnected     = on_disconnected,
-/* STEP 5.1 - Add the security_changed member to the callback structure */
+	.connected = on_connected,
+	.disconnected = on_disconnected,
+	/* STEP 5.1 - Add the security_changed member to the callback structure */
 	.security_changed = on_security_changed,
 };
 
@@ -105,7 +102,6 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 };
 
-
 static void app_led_cb(bool led_state)
 {
 	dk_set_led(USER_LED, led_state);
@@ -117,7 +113,7 @@ static bool app_button_cb(void)
 }
 
 static struct bt_lbs_cb lbs_callbacs = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -162,7 +158,7 @@ void main(void)
 		return;
 	}
 
-/* STEP 10 - Register the authentication callbacks */
+	/* STEP 10 - Register the authentication callbacks */
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		LOG_INF("Failed to register authorization callbacks\n");
@@ -185,8 +181,7 @@ void main(void)
 
 	LOG_INF("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_INF("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson5/blefund_less5_exer2/prj.conf
+++ b/lesson5/blefund_less5_exer2/prj.conf
@@ -24,6 +24,6 @@ CONFIG_BT_SMP=y
 
 # STEP 4.1 Increase the number of maximum paired devices
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson5/blefund_less5_exer2/src/lbs.c
+++ b/lesson5/blefund_less5_exer2/src/lbs.c
@@ -28,23 +28,19 @@
 #define CONFIG_BT_LBS_LOG_LEVEL 3
 LOG_MODULE_REGISTER(bt_lbs, CONFIG_BT_LBS_LOG_LEVEL);
 
-static bool                   notify_enabled;
-static bool                   button_state;
-static struct bt_lbs_cb       lbs_cb;
+static bool notify_enabled;
+static bool button_state;
+static struct bt_lbs_cb lbs_cb;
 
-static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	notify_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -69,46 +65,34 @@ static ssize_t write_led(struct bt_conn *conn,
 
 	return len;
 }
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-	BT_GATT_CCC(lbslc_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_WRITE_AUTHEN,
-			       NULL, write_led, NULL),
-);
+BT_GATT_SERVICE_DEFINE(lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
+					      BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+					      BT_GATT_PERM_READ, read_button, NULL, &button_state),
+		       BT_GATT_CCC(lbslc_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE,
+					      BT_GATT_PERM_WRITE_AUTHEN, NULL, write_led, NULL), );
 
 int bt_lbs_init(struct bt_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
@@ -121,7 +105,5 @@ int bt_lbs_send_button_state(bool button_state)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &lbs_svc.attrs[2],
-			      &button_state,
-			      sizeof(button_state));
+	return bt_gatt_notify(NULL, &lbs_svc.attrs[2], &button_state, sizeof(button_state));
 }

--- a/lesson5/blefund_less5_exer2/src/lbs.c
+++ b/lesson5/blefund_less5_exer2/src/lbs.c
@@ -70,10 +70,10 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	const char *value = attr->user_data;
 

--- a/lesson5/blefund_less5_exer2/src/lbs.h
+++ b/lesson5/blefund_less5_exer2/src/lbs.h
@@ -20,21 +20,18 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -45,7 +42,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct bt_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson5/blefund_less5_exer2/src/main.c
+++ b/lesson5/blefund_less5_exer2/src/main.c
@@ -146,7 +146,7 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 /* STEP 2.2 - Add extra button handling to remove bond information */
 
 /* STEP 4.2.2 Add extra button handling to advertise without using Accept List */
-	
+
 }
 
 static int init_button(void)

--- a/lesson5/blefund_less5_exer2/src/main.c
+++ b/lesson5/blefund_less5_exer2/src/main.c
@@ -16,20 +16,18 @@
 
 /* STEP 1.2 - Add the header file for the Settings module */
 
-
 LOG_MODULE_REGISTER(Lesson5_Exercise2, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
+#define USER_LED DK_LED3
 
-#define USER_LED                DK_LED3
-
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
 /* STEP 2.1 - Add extra button for bond deleting function */
 
@@ -54,7 +52,6 @@ static const struct bt_data sd[] = {
 
 /* STEP 3.3.2 - Define the function to loop through the bond list */
 
-
 /* STEP 3.4.1 - Define the function to advertise with the Accept List */
 
 static void on_connected(struct bt_conn *conn, uint8_t err)
@@ -74,11 +71,9 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected (reason %u)\n", reason);
 	dk_set_led_off(CON_STATUS_LED);
 	/* STEP 3.5 - Start advertising with Accept List */
-
 }
 
-static void on_security_changed(struct bt_conn *conn, bt_security_t level,
-				enum bt_security_err err)
+static void on_security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -87,13 +82,12 @@ static void on_security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		LOG_INF("Security changed: %s level %u\n", addr, level);
 	} else {
-		LOG_INF("Security failed: %s level %u err %d\n", addr, level,
-			err);
+		LOG_INF("Security failed: %s level %u err %d\n", addr, level, err);
 	}
 }
 struct bt_conn_cb connection_callbacks = {
-	.connected        = on_connected,
-	.disconnected     = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 	.security_changed = on_security_changed,
 };
 
@@ -131,7 +125,7 @@ static bool app_button_cb(void)
 }
 
 static struct bt_lbs_cb lbs_callbacs = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -143,10 +137,9 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 		bt_lbs_send_button_state(user_button_state);
 		app_button_state = user_button_state ? true : false;
 	}
-/* STEP 2.2 - Add extra button handling to remove bond information */
+	/* STEP 2.2 - Add extra button handling to remove bond information */
 
-/* STEP 4.2.2 Add extra button handling to advertise without using Accept List */
-
+	/* STEP 4.2.2 Add extra button handling to advertise without using Accept List */
 }
 
 static int init_button(void)
@@ -204,8 +197,7 @@ void main(void)
 	/* STEP 3.4.2 - Start advertising with the Accept List */
 
 	/* STEP 3.4.3 - Remove the original code that does normal advertising */
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_INF("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson5/blefund_less5_exer2/src/main.c
+++ b/lesson5/blefund_less5_exer2/src/main.c
@@ -78,7 +78,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 static void on_security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+				enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 

--- a/lesson5/blefund_less5_exer2_solution/prj.conf
+++ b/lesson5/blefund_less5_exer2_solution/prj.conf
@@ -32,6 +32,6 @@ CONFIG_BT_PRIVACY=y
 # STEP 4.1 Increase the number of maximum paired devices
 CONFIG_BT_MAX_PAIRED=5
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson5/blefund_less5_exer2_solution/src/lbs.c
+++ b/lesson5/blefund_less5_exer2_solution/src/lbs.c
@@ -28,23 +28,19 @@
 #define CONFIG_BT_LBS_LOG_LEVEL 3
 LOG_MODULE_REGISTER(bt_lbs, CONFIG_BT_LBS_LOG_LEVEL);
 
-static bool                   notify_enabled;
-static bool                   button_state;
-static struct bt_lbs_cb       lbs_cb;
+static bool notify_enabled;
+static bool button_state;
+static struct bt_lbs_cb lbs_cb;
 
-static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	notify_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -69,46 +65,34 @@ static ssize_t write_led(struct bt_conn *conn,
 
 	return len;
 }
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-	BT_GATT_CCC(lbslc_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_WRITE_AUTHEN,
-			       NULL, write_led, NULL),
-);
+BT_GATT_SERVICE_DEFINE(lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
+					      BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+					      BT_GATT_PERM_READ, read_button, NULL, &button_state),
+		       BT_GATT_CCC(lbslc_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE,
+					      BT_GATT_PERM_WRITE_AUTHEN, NULL, write_led, NULL), );
 
 int bt_lbs_init(struct bt_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
@@ -121,7 +105,5 @@ int bt_lbs_send_button_state(bool button_state)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &lbs_svc.attrs[2],
-			      &button_state,
-			      sizeof(button_state));
+	return bt_gatt_notify(NULL, &lbs_svc.attrs[2], &button_state, sizeof(button_state));
 }

--- a/lesson5/blefund_less5_exer2_solution/src/lbs.c
+++ b/lesson5/blefund_less5_exer2_solution/src/lbs.c
@@ -70,10 +70,10 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	const char *value = attr->user_data;
 

--- a/lesson5/blefund_less5_exer2_solution/src/lbs.h
+++ b/lesson5/blefund_less5_exer2_solution/src/lbs.h
@@ -20,21 +20,18 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -45,7 +42,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct bt_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson5/blefund_less5_exer2_solution/src/main.c
+++ b/lesson5/blefund_less5_exer2_solution/src/main.c
@@ -315,7 +315,7 @@ void main(void)
 	// 	LOG_INF("Advertising failed to start (err %d)\n", err);
 	// 	return;
 	// }
-	//LOG_INF("Advertising successfully started\n");
+	// LOG_INF("Advertising successfully started\n");
 
 	for (;;) {
 		dk_set_led(RUN_STATUS_LED, (++blink_status) % 2);

--- a/lesson5/blefund_less5_exer2_solution/src/main.c
+++ b/lesson5/blefund_less5_exer2_solution/src/main.c
@@ -45,7 +45,7 @@ LOG_MODULE_REGISTER(Lesson5_Exercise2, LOG_LEVEL_INF);
 /* STEP 3.2.2 - Define advertising parameter for when Accept List is used */
 #define BT_LE_ADV_CONN_ACCEPT_LIST BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_FILTER_CONN|BT_LE_ADV_OPT_ONE_TIME, \
 				       BT_GAP_ADV_FAST_INT_MIN_2, \
-				       BT_GAP_ADV_FAST_INT_MAX_2, NULL)					   
+				       BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
 
 static bool app_button_state;
@@ -104,14 +104,14 @@ void advertise_with_acceptlist (struct k_work *work)
 		LOG_INF("Acceptlist setup failed (err:%d)\n", allowed_cnt);
 	} else {
 		if (allowed_cnt==0){
-			LOG_INF("Advertising with no Accept list \n"); 
+			LOG_INF("Advertising with no Accept list \n");
 			err = bt_le_adv_start(BT_LE_ADV_CONN_NO_ACCEPT_LIST, ad, ARRAY_SIZE(ad),
 					sd, ARRAY_SIZE(sd));
 		}
 		else {
 			LOG_INF("Acceptlist setup number  = %d \n",allowed_cnt);
 			err = bt_le_adv_start(BT_LE_ADV_CONN_ACCEPT_LIST, ad, ARRAY_SIZE(ad),
-				sd, ARRAY_SIZE(sd));	
+				sd, ARRAY_SIZE(sd));
 		}
 		if (err) {
 		 	LOG_INF("Advertising failed to start (err %d)\n", err);
@@ -217,8 +217,8 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 				LOG_INF("Cannot delete bond (err: %d)\n", err);
 			} else	{
 				LOG_INF("Bond deleted succesfully");
-			}				
-			
+			}
+
 		}
 	}
 /* STEP 4.2.2 Add extra button handling to advertise without using Accept List */
@@ -236,7 +236,7 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 				LOG_INF("Cannot clear accept list (err: %d)\n", err_code);
 			} else	{
 				LOG_INF("Accept list cleared succesfully");
-			}				
+			}
 			err_code = bt_le_adv_start(BT_LE_ADV_CONN_NO_ACCEPT_LIST, ad, ARRAY_SIZE(ad),
 					sd, ARRAY_SIZE(sd));
 
@@ -245,8 +245,8 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 			} else	{
 				LOG_INF("Advertising in pairing mode started");
 
-			}	
-		}	
+			}
+		}
 	}
 }
 

--- a/lesson5/blefund_less5_exer2_solution/src/main.c
+++ b/lesson5/blefund_less5_exer2_solution/src/main.c
@@ -40,12 +40,12 @@ LOG_MODULE_REGISTER(Lesson5_Exercise2, LOG_LEVEL_INF);
 
 /* STEP 3.2.1 - Define advertising parameter for no Accept List */
 #define BT_LE_ADV_CONN_NO_ACCEPT_LIST BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_ONE_TIME, \
-				       BT_GAP_ADV_FAST_INT_MIN_2, \
-				       BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+						      BT_GAP_ADV_FAST_INT_MIN_2, \
+						      BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 /* STEP 3.2.2 - Define advertising parameter for when Accept List is used */
 #define BT_LE_ADV_CONN_ACCEPT_LIST BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_FILTER_CONN|BT_LE_ADV_OPT_ONE_TIME, \
-				       BT_GAP_ADV_FAST_INT_MIN_2, \
-				       BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+						   BT_GAP_ADV_FAST_INT_MIN_2, \
+						   BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
 
 static bool app_button_state;
@@ -144,7 +144,7 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 static void on_security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+				enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -310,7 +310,7 @@ void main(void)
 
 	/* STEP 3.4.3 - Remove the original code that does normal advertising */
 	// err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
-	// 		      sd, ARRAY_SIZE(sd));
+	// 			 sd, ARRAY_SIZE(sd));
 	// if (err) {
 	// 	LOG_INF("Advertising failed to start (err %d)\n", err);
 	// 	return;

--- a/lesson5/blefund_less5_exer2_solution/src/main.c
+++ b/lesson5/blefund_less5_exer2_solution/src/main.c
@@ -19,34 +19,34 @@
 
 LOG_MODULE_REGISTER(Lesson5_Exercise2, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
-#define USER_LED                DK_LED3
+#define USER_LED DK_LED3
 
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
 /* STEP 2.1 - Add extra button for bond deleting function */
 
-#define BOND_DELETE_BUTTON             DK_BTN2_MSK
+#define BOND_DELETE_BUTTON DK_BTN2_MSK
 
 /* STEP 4.2.1 - Add extra button for enablig pairing mode */
 
-#define PAIRING_BUTTON             DK_BTN3_MSK
+#define PAIRING_BUTTON DK_BTN3_MSK
 
 /* STEP 3.2.1 - Define advertising parameter for no Accept List */
-#define BT_LE_ADV_CONN_NO_ACCEPT_LIST BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_ONE_TIME, \
-						      BT_GAP_ADV_FAST_INT_MIN_2, \
-						      BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+#define BT_LE_ADV_CONN_NO_ACCEPT_LIST                                                              \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME,                        \
+			BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 /* STEP 3.2.2 - Define advertising parameter for when Accept List is used */
-#define BT_LE_ADV_CONN_ACCEPT_LIST BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_FILTER_CONN|BT_LE_ADV_OPT_ONE_TIME, \
-						   BT_GAP_ADV_FAST_INT_MIN_2, \
-						   BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
+#define BT_LE_ADV_CONN_ACCEPT_LIST                                                                 \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_FILTER_CONN |                    \
+				BT_LE_ADV_OPT_ONE_TIME,                                            \
+			BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
 static bool app_button_state;
 
@@ -69,7 +69,8 @@ static void setup_accept_list_cb(const struct bt_bond_info *info, void *user_dat
 	}
 
 	int err = bt_le_filter_accept_list_add(&info->addr);
-	LOG_INF("Added following peer to accept list: %x %x\n",info->addr.a.val[0],info->addr.a.val[1]);
+	LOG_INF("Added following peer to accept list: %x %x\n", info->addr.a.val[0],
+		info->addr.a.val[1]);
 	if (err) {
 		LOG_INF("Cannot add peer to filter accept list (err: %d)\n", err);
 		(*bond_cnt) = -EIO;
@@ -96,25 +97,24 @@ static int setup_accept_list(uint8_t local_id)
 }
 
 /* STEP 3.4.1 - Define the function to advertise with the Accept List */
-void advertise_with_acceptlist (struct k_work *work)
+void advertise_with_acceptlist(struct k_work *work)
 {
-	int err=0;
-	int allowed_cnt= setup_accept_list(BT_ID_DEFAULT);
-	if (allowed_cnt<0){
+	int err = 0;
+	int allowed_cnt = setup_accept_list(BT_ID_DEFAULT);
+	if (allowed_cnt < 0) {
 		LOG_INF("Acceptlist setup failed (err:%d)\n", allowed_cnt);
 	} else {
-		if (allowed_cnt==0){
+		if (allowed_cnt == 0) {
 			LOG_INF("Advertising with no Accept list \n");
-			err = bt_le_adv_start(BT_LE_ADV_CONN_NO_ACCEPT_LIST, ad, ARRAY_SIZE(ad),
-					sd, ARRAY_SIZE(sd));
-		}
-		else {
-			LOG_INF("Acceptlist setup number  = %d \n",allowed_cnt);
-			err = bt_le_adv_start(BT_LE_ADV_CONN_ACCEPT_LIST, ad, ARRAY_SIZE(ad),
-				sd, ARRAY_SIZE(sd));
+			err = bt_le_adv_start(BT_LE_ADV_CONN_NO_ACCEPT_LIST, ad, ARRAY_SIZE(ad), sd,
+					      ARRAY_SIZE(sd));
+		} else {
+			LOG_INF("Acceptlist setup number  = %d \n", allowed_cnt);
+			err = bt_le_adv_start(BT_LE_ADV_CONN_ACCEPT_LIST, ad, ARRAY_SIZE(ad), sd,
+					      ARRAY_SIZE(sd));
 		}
 		if (err) {
-		 	LOG_INF("Advertising failed to start (err %d)\n", err);
+			LOG_INF("Advertising failed to start (err %d)\n", err);
 			return;
 		}
 		LOG_INF("Advertising successfully started\n");
@@ -140,11 +140,9 @@ static void on_disconnected(struct bt_conn *conn, uint8_t reason)
 	dk_set_led_off(CON_STATUS_LED);
 	/* STEP 3.5 - Start advertising with Accept List */
 	k_work_submit(&advertise_acceptlist_work);
-
 }
 
-static void on_security_changed(struct bt_conn *conn, bt_security_t level,
-				enum bt_security_err err)
+static void on_security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -153,13 +151,12 @@ static void on_security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		LOG_INF("Security changed: %s level %u\n", addr, level);
 	} else {
-		LOG_INF("Security failed: %s level %u err %d\n", addr, level,
-			err);
+		LOG_INF("Security failed: %s level %u err %d\n", addr, level, err);
 	}
 }
 struct bt_conn_cb connection_callbacks = {
-	.connected        = on_connected,
-	.disconnected     = on_disconnected,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
 	.security_changed = on_security_changed,
 };
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
@@ -196,7 +193,7 @@ static bool app_button_cb(void)
 }
 
 static struct bt_lbs_cb lbs_callbacs = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -208,24 +205,23 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 		bt_lbs_send_button_state(user_button_state);
 		app_button_state = user_button_state ? true : false;
 	}
-/* STEP 2.2 - Add extra button handling to remove bond information */
+	/* STEP 2.2 - Add extra button handling to remove bond information */
 	if (has_changed & BOND_DELETE_BUTTON) {
 		uint32_t bond_delete_button_state = button_state & BOND_DELETE_BUTTON;
-		if (bond_delete_button_state==0) {
-			int err= bt_unpair(BT_ID_DEFAULT,BT_ADDR_LE_ANY);
+		if (bond_delete_button_state == 0) {
+			int err = bt_unpair(BT_ID_DEFAULT, BT_ADDR_LE_ANY);
 			if (err) {
 				LOG_INF("Cannot delete bond (err: %d)\n", err);
-			} else	{
+			} else {
 				LOG_INF("Bond deleted succesfully");
 			}
-
 		}
 	}
-/* STEP 4.2.2 Add extra button handling to advertise without using Accept List */
+	/* STEP 4.2.2 Add extra button handling to advertise without using Accept List */
 
 	if (has_changed & PAIRING_BUTTON) {
 		uint32_t pairing_button_state = button_state & PAIRING_BUTTON;
-		if (pairing_button_state==0) {
+		if (pairing_button_state == 0) {
 			int err_code = bt_le_adv_stop();
 			if (err_code) {
 				LOG_INF("Cannot stop advertising err= %d \n", err_code);
@@ -234,22 +230,20 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 			err_code = bt_le_filter_accept_list_clear();
 			if (err_code) {
 				LOG_INF("Cannot clear accept list (err: %d)\n", err_code);
-			} else	{
+			} else {
 				LOG_INF("Accept list cleared succesfully");
 			}
-			err_code = bt_le_adv_start(BT_LE_ADV_CONN_NO_ACCEPT_LIST, ad, ARRAY_SIZE(ad),
-					sd, ARRAY_SIZE(sd));
+			err_code = bt_le_adv_start(BT_LE_ADV_CONN_NO_ACCEPT_LIST, ad,
+						   ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 
 			if (err_code) {
 				LOG_INF("Cannot start open advertising (err: %d)\n", err_code);
-			} else	{
+			} else {
 				LOG_INF("Advertising in pairing mode started");
-
 			}
 		}
 	}
 }
-
 
 static int init_button(void)
 {

--- a/lesson6/blefund_less6_exer1/prj.conf
+++ b/lesson6/blefund_less6_exer1/prj.conf
@@ -7,13 +7,13 @@
 # Logger module
 CONFIG_LOG=y
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Bluetooth LE
 CONFIG_BT=y
 CONFIG_BT_DEVICE_NAME="Nordic_Beacon"
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson6/blefund_less6_exer1/src/main.c
+++ b/lesson6/blefund_less6_exer1/src/main.c
@@ -20,7 +20,7 @@ typedef struct adv_mfg_data {
 #define USER_BUTTON DK_BTN1_MSK
 
 static struct bt_le_adv_param *adv_param =
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options specified */
 			800, /* Min Advertising Interval 500ms (800*0.625ms) */
 			801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
 			NULL); /* Set to NULL for undirected advertising */

--- a/lesson6/blefund_less6_exer1/src/main.c
+++ b/lesson6/blefund_less6_exer1/src/main.c
@@ -21,9 +21,9 @@ typedef struct adv_mfg_data {
 #define USER_BUTTON             DK_BTN1_MSK
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified*/
-                800, /*Min Advertising Interval 500ms (800*0.625ms) */
-                801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-                NULL); /* Set to NULL for undirected advertising*/
+		800, /*Min Advertising Interval 500ms (800*0.625ms) */
+		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
+		NULL); /* Set to NULL for undirected advertising*/
 
 static adv_mfg_data_type adv_mfg_data = {COMPANY_ID_CODE,0x00};
 

--- a/lesson6/blefund_less6_exer1/src/main.c
+++ b/lesson6/blefund_less6_exer1/src/main.c
@@ -4,54 +4,55 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gap.h>
 #include <dk_buttons_and_leds.h>
 
-#define COMPANY_ID_CODE            0x0059
+#define COMPANY_ID_CODE 0x0059
 
 typedef struct adv_mfg_data {
-	uint16_t company_code;	    /* Company Identifier Code. */
-	uint16_t number_press;      /* Number of times Button 1 is pressed */
+	uint16_t company_code; /* Company Identifier Code. */
+	uint16_t number_press; /* Number of times Button 1 is pressed */
 } adv_mfg_data_type;
 
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
-		800, /* Min Advertising Interval 500ms (800*0.625ms) */
-		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
-		NULL); /* Set to NULL for undirected advertising */
+static struct bt_le_adv_param *adv_param =
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
+			800, /* Min Advertising Interval 500ms (800*0.625ms) */
+			801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+			NULL); /* Set to NULL for undirected advertising */
 
-static adv_mfg_data_type adv_mfg_data = {COMPANY_ID_CODE,0x00};
+static adv_mfg_data_type adv_mfg_data = { COMPANY_ID_CODE, 0x00 };
 
-static unsigned char url_data[] ={0x17,'/','/','a','c','a','d','e','m','y','.','n','o','r','d','i','c','s','e','m','i','.','c','o','m'};
+static unsigned char url_data[] = { 0x17, '/', '/', 'a', 'c', 'a', 'd', 'e', 'm',
+				    'y',  '.', 'n', 'o', 'r', 'd', 'i', 'c', 's',
+				    'e',  'm', 'i', '.', 'c', 'o', 'm' };
 LOG_MODULE_REGISTER(Lesson2_Exercise2, LOG_LEVEL_INF);
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED          DK_LED1
-#define RUN_LED_BLINK_INTERVAL  1000
+#define RUN_STATUS_LED DK_LED1
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_NO_BREDR),
 	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
-	BT_DATA(BT_DATA_MANUFACTURER_DATA,(unsigned char *)&adv_mfg_data, sizeof(adv_mfg_data)),
+	BT_DATA(BT_DATA_MANUFACTURER_DATA, (unsigned char *)&adv_mfg_data, sizeof(adv_mfg_data)),
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA(BT_DATA_URI, url_data,sizeof(url_data)),
+	BT_DATA(BT_DATA_URI, url_data, sizeof(url_data)),
 };
 
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	if (has_changed & button_state & USER_BUTTON) {
-	adv_mfg_data.number_press += 1;
-	bt_le_adv_update_data(ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+		adv_mfg_data.number_press += 1;
+		bt_le_adv_update_data(ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	}
 }
 
@@ -93,8 +94,7 @@ void main(void)
 
 	LOG_INF("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson6/blefund_less6_exer1/src/main.c
+++ b/lesson6/blefund_less6_exer1/src/main.c
@@ -15,15 +15,15 @@
 
 typedef struct adv_mfg_data {
 	uint16_t company_code;	    /* Company Identifier Code. */
-	uint16_t number_press;      /* Number of times Button 1 is pressed*/
+	uint16_t number_press;      /* Number of times Button 1 is pressed */
 } adv_mfg_data_type;
 
 #define USER_BUTTON             DK_BTN1_MSK
 
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified*/
-		800, /*Min Advertising Interval 500ms (800*0.625ms) */
-		801, /*Max Advertising Interval 500.625ms (801*0.625ms)*/
-		NULL); /* Set to NULL for undirected advertising*/
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(BT_LE_ADV_OPT_NONE, /* No options spesified */
+		800, /* Min Advertising Interval 500ms (800*0.625ms) */
+		801, /* Max Advertising Interval 500.625ms (801*0.625ms) */
+		NULL); /* Set to NULL for undirected advertising */
 
 static adv_mfg_data_type adv_mfg_data = {COMPANY_ID_CODE,0x00};
 

--- a/lesson6/blefund_less6_exer2/prj.conf
+++ b/lesson6/blefund_less6_exer2/prj.conf
@@ -9,7 +9,7 @@ CONFIG_LOG=y
 
 CONFIG_MAIN_STACK_SIZE=4096
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Floating Point Unit
@@ -40,6 +40,6 @@ CONFIG_BT_BUF_ACL_RX_SIZE=251
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_L2CAP_TX_MTU=247
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson6/blefund_less6_exer2/prj_nrf5340dk_nrf5340_cpuapp.conf
+++ b/lesson6/blefund_less6_exer2/prj_nrf5340dk_nrf5340_cpuapp.conf
@@ -9,7 +9,7 @@ CONFIG_LOG=y
 
 CONFIG_MAIN_STACK_SIZE=4096
 
-# Button and LED library   
+# Button and LED library
 CONFIG_DK_LIBRARY=y
 
 # Floating Point Unit

--- a/lesson6/blefund_less6_exer2/src/main.c
+++ b/lesson6/blefund_less6_exer2/src/main.c
@@ -22,7 +22,7 @@
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
 		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
 		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising*/
+		NULL); /* Set to NULL for undirected advertising */
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);

--- a/lesson6/blefund_less6_exer2/src/main.c
+++ b/lesson6/blefund_less6_exer2/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -15,33 +14,30 @@
 #include <zephyr/bluetooth/conn.h>
 #include <bluetooth/services/lbs.h>
 
-
 #include <dk_buttons_and_leds.h>
 
-
-static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-		NULL); /* Set to NULL for undirected advertising */
-
+static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+	(BT_LE_ADV_OPT_CONNECTABLE |
+	 BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
+	BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+	BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+	NULL); /* Set to NULL for undirected advertising */
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
 struct bt_conn *my_conn = NULL;
 
 static struct bt_gatt_exchange_params exchange_params;
 
-static void exchange_func(struct bt_conn *conn, uint8_t att_err, struct bt_gatt_exchange_params *params);
+static void exchange_func(struct bt_conn *conn, uint8_t att_err,
+			  struct bt_gatt_exchange_params *params);
 
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
-
-#define USER_BUTTON             DK_BTN1_MSK
-#define RUN_STATUS_LED          DK_LED1
-#define CONNECTION_STATUS_LED   DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
-
-
+#define USER_BUTTON DK_BTN1_MSK
+#define RUN_STATUS_LED DK_LED1
+#define CONNECTION_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -49,7 +45,8 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)),
 };
 
 static void update_phy(struct bt_conn *conn)
@@ -106,9 +103,10 @@ void on_connected(struct bt_conn *conn, uint8_t err)
 		LOG_ERR("bt_conn_get_info() returned %d", err);
 		return;
 	}
-	double connection_interval = info.le.interval*1.25; // in ms
-	uint16_t supervision_timeout = info.le.timeout*10; // in ms
-	LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, info.le.latency, supervision_timeout);
+	double connection_interval = info.le.interval * 1.25; // in ms
+	uint16_t supervision_timeout = info.le.timeout * 10; // in ms
+	LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms",
+		connection_interval, info.le.latency, supervision_timeout);
 
 	update_phy(my_conn);
 	update_data_length(my_conn);
@@ -122,11 +120,13 @@ void on_disconnected(struct bt_conn *conn, uint8_t reason)
 	bt_conn_unref(my_conn);
 }
 
-void on_le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency, uint16_t timeout)
+void on_le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency,
+			 uint16_t timeout)
 {
-	double connection_interval = interval*1.25;         // in ms
-	uint16_t supervision_timeout = timeout*10;          // in ms
-	LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, latency, supervision_timeout);
+	double connection_interval = interval * 1.25; // in ms
+	uint16_t supervision_timeout = timeout * 10; // in ms
+	LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms",
+		connection_interval, latency, supervision_timeout);
 }
 
 void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
@@ -134,30 +134,29 @@ void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
 	// PHY Updated
 	if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_1M) {
 		LOG_INF("PHY updated. New PHY: 1M");
-	}
-	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
+	} else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
 		LOG_INF("PHY updated. New PHY: 2M");
-	}
-	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
+	} else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
 		LOG_INF("PHY updated. New PHY: Long Range");
 	}
 }
 
 void on_le_data_len_updated(struct bt_conn *conn, struct bt_conn_le_data_len_info *info)
 {
-	uint16_t tx_len     = info->tx_max_len;
-	uint16_t tx_time    = info->tx_max_time;
-	uint16_t rx_len     = info->rx_max_len;
-	uint16_t rx_time    = info->rx_max_time;
-	LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time, rx_time);
+	uint16_t tx_len = info->tx_max_len;
+	uint16_t tx_time = info->tx_max_time;
+	uint16_t rx_len = info->rx_max_len;
+	uint16_t rx_time = info->rx_max_time;
+	LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time,
+		rx_time);
 }
 
 struct bt_conn_cb connection_callbacks = {
-	.connected              = on_connected,
-	.disconnected           = on_disconnected,
-	.le_param_updated       = on_le_param_updated,
-	.le_phy_updated         = on_le_phy_updated,
-	.le_data_len_updated    = on_le_data_len_updated,
+	.connected = on_connected,
+	.disconnected = on_disconnected,
+	.le_param_updated = on_le_param_updated,
+	.le_phy_updated = on_le_phy_updated,
+	.le_data_len_updated = on_le_data_len_updated,
 };
 
 static void exchange_func(struct bt_conn *conn, uint8_t att_err,
@@ -165,7 +164,8 @@ static void exchange_func(struct bt_conn *conn, uint8_t att_err,
 {
 	LOG_INF("MTU exchange %s", att_err == 0 ? "successful" : "failed");
 	if (!att_err) {
-		uint16_t payload_mtu = bt_gatt_get_mtu(conn) - 3;   // 3 bytes used for Attribute headers.
+		uint16_t payload_mtu =
+			bt_gatt_get_mtu(conn) - 3; // 3 bytes used for Attribute headers.
 		LOG_INF("New MTU: %d bytes", payload_mtu);
 	}
 }
@@ -213,7 +213,6 @@ void main(void)
 		return;
 	}
 
-
 	err = bt_enable(NULL);
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)", err);
@@ -222,8 +221,7 @@ void main(void)
 
 	bt_conn_cb_register(&connection_callbacks);
 	LOG_INF("Bluetooth initialized");
-	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/lesson6/blefund_less6_exer2/src/main.c
+++ b/lesson6/blefund_less6_exer2/src/main.c
@@ -20,9 +20,9 @@
 
 
 static struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM((BT_LE_ADV_OPT_CONNECTABLE|BT_LE_ADV_OPT_USE_IDENTITY), /* Connectable advertising and use identity address */
-                BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
-                BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
-                NULL); /* Set to NULL for undirected advertising*/
+		BT_GAP_ADV_FAST_INT_MIN_1, /* 0x30 units, 48 units, 30ms */
+		BT_GAP_ADV_FAST_INT_MAX_1, /* 0x60 units, 96 units, 60ms */
+		NULL); /* Set to NULL for undirected advertising*/
 
 
 LOG_MODULE_REGISTER(Lesson3_Exercise2, LOG_LEVEL_INF);
@@ -54,132 +54,132 @@ static const struct bt_data sd[] = {
 
 static void update_phy(struct bt_conn *conn)
 {
-    int err;
-    const struct bt_conn_le_phy_param preferred_phy = {
-        .options = BT_CONN_LE_PHY_OPT_NONE,
-        .pref_rx_phy = BT_GAP_LE_PHY_2M,
-        .pref_tx_phy = BT_GAP_LE_PHY_2M,
-    };
-    err = bt_conn_le_phy_update(conn, &preferred_phy);
-    if (err) {
-        LOG_ERR("bt_conn_le_phy_update() returned %d", err);
-    }
+	int err;
+	const struct bt_conn_le_phy_param preferred_phy = {
+		.options = BT_CONN_LE_PHY_OPT_NONE,
+		.pref_rx_phy = BT_GAP_LE_PHY_2M,
+		.pref_tx_phy = BT_GAP_LE_PHY_2M,
+	};
+	err = bt_conn_le_phy_update(conn, &preferred_phy);
+	if (err) {
+		LOG_ERR("bt_conn_le_phy_update() returned %d", err);
+	}
 }
 
 static void update_data_length(struct bt_conn *conn)
 {
-    int err;
-    struct bt_conn_le_data_len_param my_data_len = {
-        .tx_max_len = BT_GAP_DATA_LEN_MAX,
-        .tx_max_time = BT_GAP_DATA_TIME_MAX,
-    };
-    err = bt_conn_le_data_len_update(my_conn, &my_data_len);
-    if (err) {
-        LOG_ERR("data_len_update failed (err %d)", err);
-    }
+	int err;
+	struct bt_conn_le_data_len_param my_data_len = {
+		.tx_max_len = BT_GAP_DATA_LEN_MAX,
+		.tx_max_time = BT_GAP_DATA_TIME_MAX,
+	};
+	err = bt_conn_le_data_len_update(my_conn, &my_data_len);
+	if (err) {
+		LOG_ERR("data_len_update failed (err %d)", err);
+	}
 }
 
 static void update_mtu(struct bt_conn *conn)
 {
-    int err;
-    exchange_params.func = exchange_func;
+	int err;
+	exchange_params.func = exchange_func;
 
-    err = bt_gatt_exchange_mtu(conn, &exchange_params);
-    if (err) {
-        LOG_ERR("bt_gatt_exchange_mtu failed (err %d)", err);
-    }
+	err = bt_gatt_exchange_mtu(conn, &exchange_params);
+	if (err) {
+		LOG_ERR("bt_gatt_exchange_mtu failed (err %d)", err);
+	}
 }
 
 /* Callbacks */
 void on_connected(struct bt_conn *conn, uint8_t err)
 {
-    if (err) {
-        LOG_ERR("Connection error %d", err);
-        return;
-    }
-    LOG_INF("Connected");
-    my_conn = bt_conn_ref(conn);
-    dk_set_led(CONNECTION_STATUS_LED, 1);
-    struct bt_conn_info info;
-    err = bt_conn_get_info(conn, &info);
-    if (err) {
-        LOG_ERR("bt_conn_get_info() returned %d", err);
-        return;
-    }
-    double connection_interval = info.le.interval*1.25; // in ms
-    uint16_t supervision_timeout = info.le.timeout*10; // in ms
-    LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, info.le.latency, supervision_timeout);
+	if (err) {
+		LOG_ERR("Connection error %d", err);
+		return;
+	}
+	LOG_INF("Connected");
+	my_conn = bt_conn_ref(conn);
+	dk_set_led(CONNECTION_STATUS_LED, 1);
+	struct bt_conn_info info;
+	err = bt_conn_get_info(conn, &info);
+	if (err) {
+		LOG_ERR("bt_conn_get_info() returned %d", err);
+		return;
+	}
+	double connection_interval = info.le.interval*1.25; // in ms
+	uint16_t supervision_timeout = info.le.timeout*10; // in ms
+	LOG_INF("Connection parameters: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, info.le.latency, supervision_timeout);
 
-    update_phy(my_conn);
-    update_data_length(my_conn);
-    update_mtu(my_conn);
+	update_phy(my_conn);
+	update_data_length(my_conn);
+	update_mtu(my_conn);
 }
 
 void on_disconnected(struct bt_conn *conn, uint8_t reason)
 {
-    LOG_INF("Disconnected. Reason %d", reason);
-    dk_set_led(CONNECTION_STATUS_LED, 0);
-    bt_conn_unref(my_conn);
+	LOG_INF("Disconnected. Reason %d", reason);
+	dk_set_led(CONNECTION_STATUS_LED, 0);
+	bt_conn_unref(my_conn);
 }
 
 void on_le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency, uint16_t timeout)
 {
-    double connection_interval = interval*1.25;         // in ms
-    uint16_t supervision_timeout = timeout*10;          // in ms
-    LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, latency, supervision_timeout);
+	double connection_interval = interval*1.25;         // in ms
+	uint16_t supervision_timeout = timeout*10;          // in ms
+	LOG_INF("Connection parameters updated: interval %.2f ms, latency %d intervals, timeout %d ms", connection_interval, latency, supervision_timeout);
 }
 
 void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
 {
-    // PHY Updated
-    if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_1M) {
-        LOG_INF("PHY updated. New PHY: 1M");
-    }
-    else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
-        LOG_INF("PHY updated. New PHY: 2M");
-    }
-    else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
-        LOG_INF("PHY updated. New PHY: Long Range");
-    }
+	// PHY Updated
+	if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_1M) {
+		LOG_INF("PHY updated. New PHY: 1M");
+	}
+	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_2M) {
+		LOG_INF("PHY updated. New PHY: 2M");
+	}
+	else if (param->tx_phy == BT_CONN_LE_TX_POWER_PHY_CODED_S8) {
+		LOG_INF("PHY updated. New PHY: Long Range");
+	}
 }
 
 void on_le_data_len_updated(struct bt_conn *conn, struct bt_conn_le_data_len_info *info)
 {
-    uint16_t tx_len     = info->tx_max_len;
-    uint16_t tx_time    = info->tx_max_time;
-    uint16_t rx_len     = info->rx_max_len;
-    uint16_t rx_time    = info->rx_max_time;
-    LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time, rx_time);
+	uint16_t tx_len     = info->tx_max_len;
+	uint16_t tx_time    = info->tx_max_time;
+	uint16_t rx_len     = info->rx_max_len;
+	uint16_t rx_time    = info->rx_max_time;
+	LOG_INF("Data length updated. Length %d/%d bytes, time %d/%d us", tx_len, rx_len, tx_time, rx_time);
 }
 
 struct bt_conn_cb connection_callbacks = {
-    .connected              = on_connected,
-    .disconnected           = on_disconnected,
-    .le_param_updated       = on_le_param_updated,
-    .le_phy_updated         = on_le_phy_updated,
-    .le_data_len_updated    = on_le_data_len_updated,
+	.connected              = on_connected,
+	.disconnected           = on_disconnected,
+	.le_param_updated       = on_le_param_updated,
+	.le_phy_updated         = on_le_phy_updated,
+	.le_data_len_updated    = on_le_data_len_updated,
 };
 
 static void exchange_func(struct bt_conn *conn, uint8_t att_err,
 			  struct bt_gatt_exchange_params *params)
 {
 	LOG_INF("MTU exchange %s", att_err == 0 ? "successful" : "failed");
-    if (!att_err) {
-        uint16_t payload_mtu = bt_gatt_get_mtu(conn) - 3;   // 3 bytes used for Attribute headers.
-        LOG_INF("New MTU: %d bytes", payload_mtu);
-    }
+	if (!att_err) {
+		uint16_t payload_mtu = bt_gatt_get_mtu(conn) - 3;   // 3 bytes used for Attribute headers.
+		LOG_INF("New MTU: %d bytes", payload_mtu);
+	}
 }
 
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
-    int err;
-    if (has_changed & USER_BUTTON) {
-        LOG_INF("Button changed");
-        err = bt_lbs_send_button_state(button_state ? true : false);
-        if (err) {
-            LOG_ERR("Couldn't send notification. err: %d", err);
-        }
-    }
+	int err;
+	if (has_changed & USER_BUTTON) {
+		LOG_INF("Button changed");
+		err = bt_lbs_send_button_state(button_state ? true : false);
+		if (err) {
+			LOG_ERR("Couldn't send notification. err: %d", err);
+		}
+	}
 }
 
 static int init_button(void)
@@ -220,7 +220,7 @@ void main(void)
 		return;
 	}
 
-    bt_conn_cb_register(&connection_callbacks);
+	bt_conn_cb_register(&connection_callbacks);
 	LOG_INF("Bluetooth initialized");
 	err = bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad),
 			      sd, ARRAY_SIZE(sd));

--- a/lesson6/blefund_less6_exer2/src/main.c
+++ b/lesson6/blefund_less6_exer2/src/main.c
@@ -145,7 +145,7 @@ void on_le_phy_updated(struct bt_conn *conn, struct bt_conn_le_phy_info *param)
 
 void on_le_data_len_updated(struct bt_conn *conn, struct bt_conn_le_data_len_info *info)
 {
-    uint16_t tx_len     = info->tx_max_len; 
+    uint16_t tx_len     = info->tx_max_len;
     uint16_t tx_time    = info->tx_max_time;
     uint16_t rx_len     = info->rx_max_len;
     uint16_t rx_time    = info->rx_max_time;
@@ -206,7 +206,7 @@ void main(void)
 		LOG_ERR("LEDs init failed (err %d)", err);
 		return;
 	}
-	
+
 	err = init_button();
 	if (err) {
 		LOG_ERR("Button init failed (err %d)", err);

--- a/lesson6/blefund_less6_exer3/prj.conf
+++ b/lesson6/blefund_less6_exer3/prj.conf
@@ -17,6 +17,6 @@ CONFIG_BT_SMP=y
 
 # STEP 6 - Enable log output of LTK key
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson6/blefund_less6_exer3/src/lbs.c
+++ b/lesson6/blefund_less6_exer3/src/lbs.c
@@ -28,23 +28,19 @@
 #define CONFIG_BT_LBS_LOG_LEVEL 3
 LOG_MODULE_REGISTER(bt_lbs, CONFIG_BT_LBS_LOG_LEVEL);
 
-static bool                   notify_enabled;
-static bool                   button_state;
-static struct bt_lbs_cb       lbs_cb;
+static bool notify_enabled;
+static bool button_state;
+static struct bt_lbs_cb lbs_cb;
 
-static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	notify_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -69,47 +65,35 @@ static ssize_t write_led(struct bt_conn *conn,
 
 	return len;
 }
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-	BT_GATT_CCC(lbslc_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       // BT_GATT_PERM_WRITE_ENCRYPT,
-			       BT_GATT_PERM_WRITE_AUTHEN,
-			       NULL, write_led, NULL),
-);
+BT_GATT_SERVICE_DEFINE(lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
+					      BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+					      BT_GATT_PERM_READ, read_button, NULL, &button_state),
+		       BT_GATT_CCC(lbslc_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE,
+					      // BT_GATT_PERM_WRITE_ENCRYPT,
+					      BT_GATT_PERM_WRITE_AUTHEN, NULL, write_led, NULL), );
 
 int bt_lbs_init(struct bt_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
@@ -122,7 +106,5 @@ int bt_lbs_send_button_state(bool button_state)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &lbs_svc.attrs[2],
-			      &button_state,
-			      sizeof(button_state));
+	return bt_gatt_notify(NULL, &lbs_svc.attrs[2], &button_state, sizeof(button_state));
 }

--- a/lesson6/blefund_less6_exer3/src/lbs.c
+++ b/lesson6/blefund_less6_exer3/src/lbs.c
@@ -70,10 +70,10 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	const char *value = attr->user_data;
 
@@ -101,7 +101,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
 			       BT_GATT_CHRC_WRITE,
-			//	   BT_GATT_PERM_WRITE_ENCRYPT,
+			       // BT_GATT_PERM_WRITE_ENCRYPT,
 			       BT_GATT_PERM_WRITE_AUTHEN,
 			       NULL, write_led, NULL),
 );

--- a/lesson6/blefund_less6_exer3/src/lbs.h
+++ b/lesson6/blefund_less6_exer3/src/lbs.h
@@ -20,21 +20,18 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -45,7 +42,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct bt_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson6/blefund_less6_exer3/src/main.c
+++ b/lesson6/blefund_less6_exer3/src/main.c
@@ -26,17 +26,16 @@
 
 #include <dk_buttons_and_leds.h>
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
+#define USER_LED DK_LED3
 
-#define USER_LED                DK_LED3
-
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
 static bool app_button_state;
 
@@ -68,8 +67,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	dk_set_led_off(CON_STATUS_LED);
 }
 
-static void security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -78,13 +76,12 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		printk("Security changed: %s level %u\n", addr, level);
 	} else {
-		printk("Security failed: %s level %u err %d\n", addr, level,
-			err);
+		printk("Security failed: %s level %u err %d\n", addr, level, err);
 	}
 }
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected        = connected,
-	.disconnected     = disconnected,
+	.connected = connected,
+	.disconnected = disconnected,
 	.security_changed = security_changed,
 };
 
@@ -111,8 +108,6 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 };
 
-
-
 static void app_led_cb(bool led_state)
 {
 	dk_set_led(USER_LED, led_state);
@@ -124,7 +119,7 @@ static bool app_button_cb(void)
 }
 
 static struct bt_lbs_cb lbs_callbacs = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -189,8 +184,7 @@ void main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson6/blefund_less6_exer3/src/main.c
+++ b/lesson6/blefund_less6_exer3/src/main.c
@@ -182,7 +182,7 @@ void main(void)
 	}
 
 	printk("Bluetooth initialized\n");
-	
+
 	err = bt_lbs_init(&lbs_callbacs);
 	if (err) {
 		printk("Failed to init LBS (err:%d)\n", err);

--- a/lesson6/blefund_less6_exer3_solution/prj.conf
+++ b/lesson6/blefund_less6_exer3_solution/prj.conf
@@ -18,6 +18,6 @@ CONFIG_BT_SMP=y
 CONFIG_BT_DEBUG_LOG=y
 CONFIG_BT_LOG_SNIFFER_INFO=y
 
-# Increase stack size for the main thread and System Workqueue 
+# Increase stack size for the main thread and System Workqueue
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_MAIN_STACK_SIZE=2048

--- a/lesson6/blefund_less6_exer3_solution/src/lbs.c
+++ b/lesson6/blefund_less6_exer3_solution/src/lbs.c
@@ -28,23 +28,19 @@
 #define CONFIG_BT_LBS_LOG_LEVEL 3
 LOG_MODULE_REGISTER(bt_lbs, CONFIG_BT_LBS_LOG_LEVEL);
 
-static bool                   notify_enabled;
-static bool                   button_state;
-static struct bt_lbs_cb       lbs_cb;
+static bool notify_enabled;
+static bool button_state;
+static struct bt_lbs_cb lbs_cb;
 
-static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr,
-				  uint16_t value)
+static void lbslc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
 	notify_enabled = (value == BT_GATT_CCC_NOTIFY);
 }
 
-static ssize_t write_led(struct bt_conn *conn,
-			 const struct bt_gatt_attr *attr,
-			 const void *buf,
+static ssize_t write_led(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
-	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute write, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (len != 1U) {
 		LOG_DBG("Write led: Incorrect data length");
@@ -69,47 +65,35 @@ static ssize_t write_led(struct bt_conn *conn,
 
 	return len;
 }
-static ssize_t read_button(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr,
-			   void *buf,
-			   uint16_t len,
-			   uint16_t offset)
+static ssize_t read_button(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle,
-		(void *)conn);
+	LOG_DBG("Attribute read, handle: %u, conn: %p", attr->handle, (void *)conn);
 
 	if (lbs_cb.button_cb) {
 		button_state = lbs_cb.button_cb();
-		return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-					 sizeof(*value));
+		return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(*value));
 	}
 
 	return 0;
 }
 
-
 /* LED Button Service Declaration */
-BT_GATT_SERVICE_DEFINE(lbs_svc,
-BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
-			       BT_GATT_PERM_READ, read_button, NULL,
-			       &button_state),
-	BT_GATT_CCC(lbslc_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
-	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
-			       BT_GATT_CHRC_WRITE,
-			       // BT_GATT_PERM_WRITE_ENCRYPT,
-			       BT_GATT_PERM_WRITE_AUTHEN,
-			       NULL, write_led, NULL),
-);
+BT_GATT_SERVICE_DEFINE(lbs_svc, BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_BUTTON,
+					      BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+					      BT_GATT_PERM_READ, read_button, NULL, &button_state),
+		       BT_GATT_CCC(lbslc_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+		       BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED, BT_GATT_CHRC_WRITE,
+					      // BT_GATT_PERM_WRITE_ENCRYPT,
+					      BT_GATT_PERM_WRITE_AUTHEN, NULL, write_led, NULL), );
 
 int bt_lbs_init(struct bt_lbs_cb *callbacks)
 {
 	if (callbacks) {
-		lbs_cb.led_cb    = callbacks->led_cb;
+		lbs_cb.led_cb = callbacks->led_cb;
 		lbs_cb.button_cb = callbacks->button_cb;
 	}
 
@@ -122,7 +106,5 @@ int bt_lbs_send_button_state(bool button_state)
 		return -EACCES;
 	}
 
-	return bt_gatt_notify(NULL, &lbs_svc.attrs[2],
-			      &button_state,
-			      sizeof(button_state));
+	return bt_gatt_notify(NULL, &lbs_svc.attrs[2], &button_state, sizeof(button_state));
 }

--- a/lesson6/blefund_less6_exer3_solution/src/lbs.c
+++ b/lesson6/blefund_less6_exer3_solution/src/lbs.c
@@ -70,10 +70,10 @@ static ssize_t write_led(struct bt_conn *conn,
 	return len;
 }
 static ssize_t read_button(struct bt_conn *conn,
-			  const struct bt_gatt_attr *attr,
-			  void *buf,
-			  uint16_t len,
-			  uint16_t offset)
+			   const struct bt_gatt_attr *attr,
+			   void *buf,
+			   uint16_t len,
+			   uint16_t offset)
 {
 	const char *value = attr->user_data;
 
@@ -101,7 +101,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_LBS),
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 	BT_GATT_CHARACTERISTIC(BT_UUID_LBS_LED,
 			       BT_GATT_CHRC_WRITE,
-			//	   BT_GATT_PERM_WRITE_ENCRYPT,
+			       // BT_GATT_PERM_WRITE_ENCRYPT,
 			       BT_GATT_PERM_WRITE_AUTHEN,
 			       NULL, write_led, NULL),
 );

--- a/lesson6/blefund_less6_exer3_solution/src/lbs.h
+++ b/lesson6/blefund_less6_exer3_solution/src/lbs.h
@@ -20,21 +20,18 @@ extern "C" {
 #include <zephyr/types.h>
 
 /** @brief LBS Service UUID. */
-#define BT_UUID_LBS_VAL \
-	BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_VAL BT_UUID_128_ENCODE(0x00001523, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief Button Characteristic UUID. */
-#define BT_UUID_LBS_BUTTON_VAL \
+#define BT_UUID_LBS_BUTTON_VAL                                                                     \
 	BT_UUID_128_ENCODE(0x00001524, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
 /** @brief LED Characteristic UUID. */
-#define BT_UUID_LBS_LED_VAL \
-	BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
+#define BT_UUID_LBS_LED_VAL BT_UUID_128_ENCODE(0x00001525, 0x1212, 0xefde, 0x1523, 0x785feabcd123)
 
-
-#define BT_UUID_LBS           BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
-#define BT_UUID_LBS_BUTTON    BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
-#define BT_UUID_LBS_LED       BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
+#define BT_UUID_LBS BT_UUID_DECLARE_128(BT_UUID_LBS_VAL)
+#define BT_UUID_LBS_BUTTON BT_UUID_DECLARE_128(BT_UUID_LBS_BUTTON_VAL)
+#define BT_UUID_LBS_LED BT_UUID_DECLARE_128(BT_UUID_LBS_LED_VAL)
 
 /** @brief Callback type for when an LED state change is received. */
 typedef void (*led_cb_t)(const bool led_state);
@@ -45,7 +42,7 @@ typedef bool (*button_cb_t)(void);
 /** @brief Callback struct used by the LBS Service. */
 struct bt_lbs_cb {
 	/** LED state change callback. */
-	led_cb_t    led_cb;
+	led_cb_t led_cb;
 	/** Button read callback. */
 	button_cb_t button_cb;
 };

--- a/lesson6/blefund_less6_exer3_solution/src/main.c
+++ b/lesson6/blefund_less6_exer3_solution/src/main.c
@@ -26,17 +26,16 @@
 
 #include <dk_buttons_and_leds.h>
 
-#define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+#define RUN_STATUS_LED DK_LED1
+#define CON_STATUS_LED DK_LED2
+#define RUN_LED_BLINK_INTERVAL 1000
 
-#define RUN_STATUS_LED          DK_LED1
-#define CON_STATUS_LED          DK_LED2
-#define RUN_LED_BLINK_INTERVAL  1000
+#define USER_LED DK_LED3
 
-#define USER_LED                DK_LED3
-
-#define USER_BUTTON             DK_BTN1_MSK
+#define USER_BUTTON DK_BTN1_MSK
 
 static bool app_button_state;
 
@@ -68,8 +67,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	dk_set_led_off(CON_STATUS_LED);
 }
 
-static void security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -78,13 +76,12 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		printk("Security changed: %s level %u\n", addr, level);
 	} else {
-		printk("Security failed: %s level %u err %d\n", addr, level,
-			err);
+		printk("Security failed: %s level %u err %d\n", addr, level, err);
 	}
 }
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected        = connected,
-	.disconnected     = disconnected,
+	.connected = connected,
+	.disconnected = disconnected,
 	.security_changed = security_changed,
 };
 
@@ -111,8 +108,6 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 };
 
-
-
 static void app_led_cb(bool led_state)
 {
 	dk_set_led(USER_LED, led_state);
@@ -124,7 +119,7 @@ static bool app_button_cb(void)
 }
 
 static struct bt_lbs_cb lbs_callbacs = {
-	.led_cb    = app_led_cb,
+	.led_cb = app_led_cb,
 	.button_cb = app_button_cb,
 };
 
@@ -189,8 +184,7 @@ void main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
-			      sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/lesson6/blefund_less6_exer3_solution/src/main.c
+++ b/lesson6/blefund_less6_exer3_solution/src/main.c
@@ -182,7 +182,7 @@ void main(void)
 	}
 
 	printk("Bluetooth initialized\n");
-	
+
 	err = bt_lbs_init(&lbs_callbacs);
 	if (err) {
 		printk("Failed to init LBS (err:%d)\n", err);


### PR DESCRIPTION
Fixed formatting related to tabs/spaces, remove trailing whitespaces, added missing newlines at the end of the files. Run clang-format with Zephyr-compatible formatting.

If you decide that the clang-format step is unnecessary, it can be reverted. For tabs/spaces, I believe the changes should be applied as they make the code harder to work with.