### PR TITLE
Support for v2.7.0

### DIFF
--- a/v2.9.0-v2.7.0/l4/l4_e3/Kconfig
+++ b/v2.9.0-v2.7.0/l4/l4_e3/Kconfig
@@ -36,10 +36,8 @@ config BT_NUS_UART_RX_WAIT_TIME
 config SETTINGS
 	default y
 
-config ZMS
-	default y if SOC_FLASH_NRF_RRAM
 
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 endmenu

--- a/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3/src/main.c
+++ b/v2.9.0-v2.7.0/l4/l4_e3/src/main.c
@@ -38,12 +38,12 @@
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define STACKSIZE CONFIG_BT_NUS_THREAD_STACK_SIZE
-#define PRIORITY 7
+#define PRIORITY  7
 
-#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN	(sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME	CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED DK_LED1
+#define RUN_STATUS_LED	       DK_LED1
 #define RUN_LED_BLINK_INTERVAL 1000
 
 #define CON_STATUS_LED DK_LED2
@@ -51,9 +51,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define KEY_PASSKEY_ACCEPT DK_BTN1_MSK
 #define KEY_PASSKEY_REJECT DK_BTN2_MSK
 
-#define UART_BUF_SIZE CONFIG_BT_NUS_UART_BUFFER_SIZE
+#define UART_BUF_SIZE		CONFIG_BT_NUS_UART_BUFFER_SIZE
 #define UART_WAIT_FOR_BUF_DELAY K_MSEC(50)
-#define UART_WAIT_FOR_RX CONFIG_BT_NUS_UART_RX_WAIT_TIME
+#define UART_WAIT_FOR_RX	CONFIG_BT_NUS_UART_RX_WAIT_TIME
 
 static K_SEM_DEFINE(ble_init_ok, 0, 1);
 
@@ -93,19 +93,16 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 	switch (evt->type) {
 	case UART_TX_DONE:
 		LOG_DBG("UART_TX_DONE");
-		if ((evt->data.tx.len == 0) ||
-		    (!evt->data.tx.buf)) {
+		if ((evt->data.tx.len == 0) || (!evt->data.tx.buf)) {
 			return;
 		}
 
 		if (aborted_buf) {
-			buf = CONTAINER_OF(aborted_buf, struct uart_data_t,
-					   data[0]);
+			buf = CONTAINER_OF(aborted_buf, struct uart_data_t, data[0]);
 			aborted_buf = NULL;
 			aborted_len = 0;
 		} else {
-			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t,
-					   data[0]);
+			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t, data[0]);
 		}
 
 		k_free(buf);
@@ -151,8 +148,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 			return;
 		}
 
-		uart_rx_enable(uart, buf->data, sizeof(buf->data),
-			       UART_WAIT_FOR_RX);
+		uart_rx_enable(uart, buf->data, sizeof(buf->data), UART_WAIT_FOR_RX);
 
 		break;
 
@@ -170,11 +166,11 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 
 	case UART_RX_BUF_RELEASED:
 		LOG_DBG("UART_RX_BUF_RELEASED");
-		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t,
-				   data[0]);
+		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t, data[0]);
 
 		if (buf->len > 0) {
-			/* STEP 9.1 -  Push the data received from the UART peripheral into the fifo_uart_rx_data FIFO */			
+			/* STEP 9.1 -  Push the data received from the UART peripheral into the
+			 * fifo_uart_rx_data FIFO */
 
 		} else {
 			k_free(buf);
@@ -189,11 +185,9 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		aborted_len += evt->data.tx.len;
-		buf = CONTAINER_OF((void *)aborted_buf, struct uart_data_t,
-				   data);
+		buf = CONTAINER_OF((void *)aborted_buf, struct uart_data_t, data);
 
-		uart_tx(uart, &buf->data[aborted_len],
-			buf->len - aborted_len, SYS_FOREVER_MS);
+		uart_tx(uart, &buf->data[aborted_len], buf->len - aborted_len, SYS_FOREVER_MS);
 
 		break;
 
@@ -220,8 +214,7 @@ static void uart_work_handler(struct k_work *item)
 
 static bool uart_test_async_api(const struct device *dev)
 {
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
 
 	return (api->callback_set != NULL);
 }
@@ -253,7 +246,6 @@ static int uart_init(void)
 	}
 
 	k_work_init_delayable(&uart_work, uart_work_handler);
-
 
 	if (IS_ENABLED(CONFIG_UART_ASYNC_ADAPTER) && !uart_test_async_api(uart)) {
 		/* Implement API adapter */
@@ -333,7 +325,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	if (err) {
-		LOG_ERR("Connection failed, err 0x%02x %s", err, bt_hci_err_to_str(err));
+		LOG_ERR("Connection failed, err 0x%02x ", err);
 		return;
 	}
 
@@ -351,7 +343,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	LOG_INF("Disconnected: %s, reason 0x%02x %s", addr, reason, bt_hci_err_to_str(reason));
+	LOG_INF("Disconnected: %s, reason 0x%02x", addr, reason);
 
 	if (auth_conn) {
 		bt_conn_unref(auth_conn);
@@ -366,8 +358,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
-static void security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -376,14 +367,13 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		LOG_INF("Security changed: %s level %u", addr, level);
 	} else {
-		LOG_WRN("Security failed: %s level %u err %d %s", addr, level, err,
-			bt_security_err_to_str(err));
+		LOG_WRN("Security failed: %s level %u err %d", addr, level, err);
 	}
 }
 #endif
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected    = connected,
+	.connected = connected,
 	.disconnected = disconnected,
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
 	.security_changed = security_changed,
@@ -417,7 +407,6 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	}
 }
 
-
 static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -426,7 +415,6 @@ static void auth_cancel(struct bt_conn *conn)
 
 	LOG_INF("Pairing cancelled: %s", addr);
 }
-
 
 static void pairing_complete(struct bt_conn *conn, bool bonded)
 {
@@ -437,15 +425,13 @@ static void pairing_complete(struct bt_conn *conn, bool bonded)
 	LOG_INF("Pairing completed: %s, bonded: %d", addr, bonded);
 }
 
-
 static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	LOG_INF("Pairing failed conn: %s, reason %d %s", addr, reason,
-		bt_security_err_to_str(reason));
+	LOG_INF("Pairing failed conn: %s, reason %d", addr, reason);
 }
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
@@ -454,17 +440,14 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 };
 
-static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
-	.pairing_complete = pairing_complete,
-	.pairing_failed = pairing_failed
-};
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {.pairing_complete = pairing_complete,
+							       .pairing_failed = pairing_failed};
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
 static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
 #endif
 
-static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
-			  uint16_t len)
+static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
 {
 	int err;
 	char addr[BT_ADDR_LE_STR_LEN] = {0};
@@ -572,7 +555,6 @@ int main(void)
 	configure_gpio();
 	/* STEP 7 - Initialize the UART Peripheral  */
 
-
 	if (IS_ENABLED(CONFIG_BT_NUS_SECURITY_ENABLED)) {
 		err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 		if (err) {
@@ -601,9 +583,7 @@ int main(void)
 	}
 	/* STEP 8.2 - Pass your application callback function to the NUS service */
 
-
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,
-			      ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return 0;

--- a/v2.9.0-v2.7.0/l4/l4_e3_sol/Kconfig
+++ b/v2.9.0-v2.7.0/l4/l4_e3_sol/Kconfig
@@ -36,10 +36,7 @@ config BT_NUS_UART_RX_WAIT_TIME
 config SETTINGS
 	default y
 
-config ZMS
-	default y if SOC_FLASH_NRF_RRAM
-
 config NVS
-	default y if !SOC_FLASH_NRF_RRAM
+	default y if !(SOC_FLASH_NRF_RRAM || SOC_FLASH_NRF_MRAM)
 
 endmenu

--- a/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54l15dk_nrf54l15_cpuapp_ns.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/v2.9.0-v2.7.0/l4/l4_e3_sol/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -6,3 +6,4 @@
 
 # Disable the unspupported UART0 driver
 CONFIG_NRFX_UARTE0=n
+CONFIG_ZMS=y

--- a/v2.9.0-v2.7.0/l4/l4_e3_sol/src/main.c
+++ b/v2.9.0-v2.7.0/l4/l4_e3_sol/src/main.c
@@ -38,12 +38,12 @@
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define STACKSIZE CONFIG_BT_NUS_THREAD_STACK_SIZE
-#define PRIORITY 7
+#define PRIORITY  7
 
-#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN	(sizeof(DEVICE_NAME) - 1)
+#define DEVICE_NAME	CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
-#define RUN_STATUS_LED DK_LED1
+#define RUN_STATUS_LED	       DK_LED1
 #define RUN_LED_BLINK_INTERVAL 1000
 
 #define CON_STATUS_LED DK_LED2
@@ -51,9 +51,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define KEY_PASSKEY_ACCEPT DK_BTN1_MSK
 #define KEY_PASSKEY_REJECT DK_BTN2_MSK
 
-#define UART_BUF_SIZE CONFIG_BT_NUS_UART_BUFFER_SIZE
+#define UART_BUF_SIZE		CONFIG_BT_NUS_UART_BUFFER_SIZE
 #define UART_WAIT_FOR_BUF_DELAY K_MSEC(50)
-#define UART_WAIT_FOR_RX CONFIG_BT_NUS_UART_RX_WAIT_TIME
+#define UART_WAIT_FOR_RX	CONFIG_BT_NUS_UART_RX_WAIT_TIME
 
 static K_SEM_DEFINE(ble_init_ok, 0, 1);
 
@@ -99,19 +99,16 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 	switch (evt->type) {
 	case UART_TX_DONE:
 		LOG_DBG("UART_TX_DONE");
-		if ((evt->data.tx.len == 0) ||
-		    (!evt->data.tx.buf)) {
+		if ((evt->data.tx.len == 0) || (!evt->data.tx.buf)) {
 			return;
 		}
 
 		if (aborted_buf) {
-			buf = CONTAINER_OF(aborted_buf, struct uart_data_t,
-					   data[0]);
+			buf = CONTAINER_OF(aborted_buf, struct uart_data_t, data[0]);
 			aborted_buf = NULL;
 			aborted_len = 0;
 		} else {
-			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t,
-					   data[0]);
+			buf = CONTAINER_OF(evt->data.tx.buf, struct uart_data_t, data[0]);
 		}
 
 		k_free(buf);
@@ -157,8 +154,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 			return;
 		}
 
-		uart_rx_enable(uart, buf->data, sizeof(buf->data),
-			       UART_WAIT_FOR_RX);
+		uart_rx_enable(uart, buf->data, sizeof(buf->data), UART_WAIT_FOR_RX);
 
 		break;
 
@@ -176,11 +172,11 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 
 	case UART_RX_BUF_RELEASED:
 		LOG_DBG("UART_RX_BUF_RELEASED");
-		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t,
-				   data[0]);
+		buf = CONTAINER_OF(evt->data.rx_buf.buf, struct uart_data_t, data[0]);
 
 		if (buf->len > 0) {
-			/* STEP 9.1 -  Push the data received from the UART peripheral into the fifo_uart_rx_data FIFO */			
+			/* STEP 9.1 -  Push the data received from the UART peripheral into the
+			 * fifo_uart_rx_data FIFO */
 			k_fifo_put(&fifo_uart_rx_data, buf);
 		} else {
 			k_free(buf);
@@ -195,11 +191,9 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 		}
 
 		aborted_len += evt->data.tx.len;
-		buf = CONTAINER_OF((void *)aborted_buf, struct uart_data_t,
-				   data);
+		buf = CONTAINER_OF((void *)aborted_buf, struct uart_data_t, data);
 
-		uart_tx(uart, &buf->data[aborted_len],
-			buf->len - aborted_len, SYS_FOREVER_MS);
+		uart_tx(uart, &buf->data[aborted_len], buf->len - aborted_len, SYS_FOREVER_MS);
 
 		break;
 
@@ -226,8 +220,7 @@ static void uart_work_handler(struct k_work *item)
 
 static bool uart_test_async_api(const struct device *dev)
 {
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
 
 	return (api->callback_set != NULL);
 }
@@ -259,7 +252,6 @@ static int uart_init(void)
 	}
 
 	k_work_init_delayable(&uart_work, uart_work_handler);
-
 
 	if (IS_ENABLED(CONFIG_UART_ASYNC_ADAPTER) && !uart_test_async_api(uart)) {
 		/* Implement API adapter */
@@ -339,7 +331,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	if (err) {
-		LOG_ERR("Connection failed, err 0x%02x %s", err, bt_hci_err_to_str(err));
+		LOG_ERR("Connection failed, err 0x%02x ", err);
 		return;
 	}
 
@@ -357,7 +349,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	LOG_INF("Disconnected: %s, reason 0x%02x %s", addr, reason, bt_hci_err_to_str(reason));
+	LOG_INF("Disconnected: %s, reason 0x%02x", addr, reason);
 
 	if (auth_conn) {
 		bt_conn_unref(auth_conn);
@@ -372,8 +364,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 }
 
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
-static void security_changed(struct bt_conn *conn, bt_security_t level,
-			     enum bt_security_err err)
+static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
@@ -382,14 +373,13 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	if (!err) {
 		LOG_INF("Security changed: %s level %u", addr, level);
 	} else {
-		LOG_WRN("Security failed: %s level %u err %d %s", addr, level, err,
-			bt_security_err_to_str(err));
+		LOG_WRN("Security failed: %s level %u err %d", addr, level, err);
 	}
 }
 #endif
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected    = connected,
+	.connected = connected,
 	.disconnected = disconnected,
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
 	.security_changed = security_changed,
@@ -423,7 +413,6 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 	}
 }
 
-
 static void auth_cancel(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -432,7 +421,6 @@ static void auth_cancel(struct bt_conn *conn)
 
 	LOG_INF("Pairing cancelled: %s", addr);
 }
-
 
 static void pairing_complete(struct bt_conn *conn, bool bonded)
 {
@@ -443,15 +431,13 @@ static void pairing_complete(struct bt_conn *conn, bool bonded)
 	LOG_INF("Pairing completed: %s, bonded: %d", addr, bonded);
 }
 
-
 static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	LOG_INF("Pairing failed conn: %s, reason %d %s", addr, reason,
-		bt_security_err_to_str(reason));
+	LOG_INF("Pairing failed conn: %s, reason %d", addr, reason);
 }
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
@@ -460,17 +446,14 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 };
 
-static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
-	.pairing_complete = pairing_complete,
-	.pairing_failed = pairing_failed
-};
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {.pairing_complete = pairing_complete,
+							       .pairing_failed = pairing_failed};
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
 static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
 #endif
 
-static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,
-			  uint16_t len)
+static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
 {
 	int err;
 	char addr[BT_ADDR_LE_STR_LEN] = {0};
@@ -622,8 +605,7 @@ int main(void)
 		return 0;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,
-			      ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return 0;
@@ -645,8 +627,7 @@ void ble_write_thread(void)
 
 	for (;;) {
 		/* Wait indefinitely for data to be sent over bluetooth */
-		struct uart_data_t *buf = k_fifo_get(&fifo_uart_rx_data,
-						     K_FOREVER);
+		struct uart_data_t *buf = k_fifo_get(&fifo_uart_rx_data, K_FOREVER);
 
 		int plen = MIN(sizeof(nus_data.data) - nus_data.len, buf->len);
 		int loc = 0;
@@ -657,8 +638,8 @@ void ble_write_thread(void)
 			loc += plen;
 
 			if (nus_data.len >= sizeof(nus_data.data) ||
-			   (nus_data.data[nus_data.len - 1] == '\n') ||
-			   (nus_data.data[nus_data.len - 1] == '\r')) {
+			    (nus_data.data[nus_data.len - 1] == '\n') ||
+			    (nus_data.data[nus_data.len - 1] == '\r')) {
 				if (bt_nus_send(NULL, nus_data.data, nus_data.len)) {
 					LOG_WRN("Failed to send data over BLE connection");
 				}
@@ -672,5 +653,4 @@ void ble_write_thread(void)
 	}
 }
 /* STEP 9.2 - Create a dedicated thread for sending the data over Bluetooth LE. */
-K_THREAD_DEFINE(ble_write_thread_id, STACKSIZE, ble_write_thread, NULL, NULL,
-		NULL, PRIORITY, 0, 0);
+K_THREAD_DEFINE(ble_write_thread_id, STACKSIZE, ble_write_thread, NULL, NULL, NULL, PRIORITY, 0, 0);


### PR DESCRIPTION
Moved ZMS to board configration files. 
Removed debug functions bt_hci_err_to_str() and bt_security_err_to_str() avaiable only in v2.9.0