### PR TITLE
remove CONFIG_BT_LBS_POLL_BUTTON

### DIFF
--- a/l3/l3_e1_sol/prj.conf
+++ b/l3/l3_e1_sol/prj.conf
@@ -17,7 +17,6 @@ CONFIG_BT_DEVICE_NAME="Nordic_Peripheral"
 
 # STEP 8.1 - Add the LBS Service
 CONFIG_BT_LBS=y
-CONFIG_BT_LBS_POLL_BUTTON=y
 
 # Increase stack size for the main thread, System Workqueue, BT RX thread and TX buf count
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048

--- a/l3/l3_e2/prj.conf
+++ b/l3/l3_e2/prj.conf
@@ -20,7 +20,6 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="Nordic_Peripheral"
 CONFIG_BT_LBS=y
-CONFIG_BT_LBS_POLL_BUTTON=y
 CONFIG_BT_GATT_CLIENT=y
 
 # STEP 5 - Configure your preferred connection parameters

--- a/l3/l3_e2_sol/prj.conf
+++ b/l3/l3_e2_sol/prj.conf
@@ -20,7 +20,6 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="Nordic_Peripheral"
 CONFIG_BT_LBS=y
-CONFIG_BT_LBS_POLL_BUTTON=y
 CONFIG_BT_GATT_CLIENT=y
 
 # STEP 5 - Configure your preferred connection parameters


### PR DESCRIPTION
Removing CONFIG_BT_LBS_POLL_BUTTON from the application. It is no longer being used in the course, as exercise 2 was changed.